### PR TITLE
Bugfix/peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,20 +14,20 @@
             },
             "devDependencies": {
                 "@remotex-labs/xbuild": "1.6.0",
-                "@remotex-labs/xjet": "^1.1.1",
-                "@types/node": "^24.6.1",
+                "@remotex-labs/xjet": "^1.3.4",
+                "@types/node": "^24.8.1",
                 "@viteplus/versions": "^2.0.2",
-                "eslint": "^9.35.0",
-                "eslint-plugin-perfectionist": "^4.15.0",
+                "eslint": "^9.38.0",
+                "eslint-plugin-perfectionist": "^4.15.1",
                 "eslint-plugin-tsdoc": "^0.4.0",
                 "markdownlint-cli": "^0.45.0",
-                "typescript-eslint": "^8.45.0"
+                "typescript-eslint": "^8.46.1"
             },
             "engines": {
                 "node": ">=20"
             },
             "peerDependencies": {
-                "vitepress": "^1.6.4"
+                "vitepress": "^1.6.4 || ^2.0.0"
             },
             "peerDependenciesMeta": {
                 "vitepress": {
@@ -552,13 +552,13 @@
             }
         },
         "node_modules/@eslint/config-array": {
-            "version": "0.21.0",
-            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
-            "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
+            "version": "0.21.1",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
+            "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/object-schema": "^2.1.6",
+                "@eslint/object-schema": "^2.1.7",
                 "debug": "^4.3.1",
                 "minimatch": "^3.1.2"
             },
@@ -567,19 +567,22 @@
             }
         },
         "node_modules/@eslint/config-helpers": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
-            "integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.1.tgz",
+            "integrity": "sha512-csZAzkNhsgwb0I/UAV6/RGFTbiakPCf0ZrGmrIxQpYvGZ00PhTkSnyKNolphgIvmnJeGw6rcGVEXfTzUnFuEvw==",
             "dev": true,
             "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/core": "^0.16.0"
+            },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
         "node_modules/@eslint/core": {
-            "version": "0.15.2",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
-            "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
+            "version": "0.16.0",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.16.0.tgz",
+            "integrity": "sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -614,9 +617,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.36.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.36.0.tgz",
-            "integrity": "sha512-uhCbYtYynH30iZErszX78U+nR3pJU3RHGQ57NXy5QupD4SBVwDeU8TNBy+MjMngc1UyIW9noKqsRqfjQTBU2dw==",
+            "version": "9.38.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.38.0.tgz",
+            "integrity": "sha512-UZ1VpFvXf9J06YG9xQBdnzU+kthors6KjhMAl6f4gH4usHyh31rUf2DLGInT8RFYIReYXNSydgPY0V2LuWgl7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -627,9 +630,9 @@
             }
         },
         "node_modules/@eslint/object-schema": {
-            "version": "2.1.6",
-            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
-            "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+            "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -637,13 +640,13 @@
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
-            "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.0.tgz",
+            "integrity": "sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/core": "^0.15.2",
+                "@eslint/core": "^0.16.0",
                 "levn": "^0.4.1"
             },
             "engines": {
@@ -961,18 +964,18 @@
             }
         },
         "node_modules/@remotex-labs/xjet": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@remotex-labs/xjet/-/xjet-1.1.1.tgz",
-            "integrity": "sha512-2QC633PRURWfmUV2N1Z3aeKRD58kGF87cFxJinQJ/D0aHjuEhp2ZyYsy57bbu9jxQNrWsTY3s7DnJ2D2JjQoHw==",
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/@remotex-labs/xjet/-/xjet-1.3.4.tgz",
+            "integrity": "sha512-3JKGBdGnkwehFtUsvvA5I9+hQj8vFBZ0qVvAC0YRyh966nd5ovIjrrYr6sGLtLbWSGzWrE513sc7HQsDee5DnA==",
             "dev": true,
             "license": "Mozilla Public License Version 2.0",
             "dependencies": {
-                "@remotex-labs/xansi": "^1.3.2",
-                "@remotex-labs/xjet-expect": "^2.1.0",
+                "@remotex-labs/xansi": "^1.3.3",
+                "@remotex-labs/xjet-expect": "^2.1.4",
                 "@remotex-labs/xmap": "^4.0.2",
                 "@remotex-labs/xstruct": "^2.0.0",
                 "esbuild": "^0.25.9",
-                "typescript": "^5.9.2",
+                "typescript": "^5.9.3",
                 "yargs": "^18.0.0"
             },
             "bin": {
@@ -985,13 +988,13 @@
             }
         },
         "node_modules/@remotex-labs/xjet-expect": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@remotex-labs/xjet-expect/-/xjet-expect-2.1.0.tgz",
-            "integrity": "sha512-04KWs+KQduOSCReBnAqvTGBpWIWd8JZRF28IfhL0WzCUOQI10BmIQGoadT/8/1YdFj4C0IIRcMD0UY113/84dA==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@remotex-labs/xjet-expect/-/xjet-expect-2.1.4.tgz",
+            "integrity": "sha512-RbQmUesOr/iJDCui1LpQE+kIGDu6JOTbHwsOS0wpJyBfuWBTm4Rnl9eAYG2Abqceq/8It/Sp7zpabrOrAUxzcg==",
             "dev": true,
             "license": "Mozilla Public License Version 2.0",
             "dependencies": {
-                "@remotex-labs/xansi": "^1.2.0"
+                "@remotex-labs/xansi": "^1.3.3"
             },
             "engines": {
                 "node": ">=20"
@@ -1609,13 +1612,13 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "24.6.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.6.1.tgz",
-            "integrity": "sha512-ljvjjs3DNXummeIaooB4cLBKg2U6SPI6Hjra/9rRIy7CpM0HpLtG9HptkMKAb4HYWy5S7HUvJEuWgr/y0U8SHw==",
+            "version": "24.8.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.8.1.tgz",
+            "integrity": "sha512-alv65KGRadQVfVcG69MuB4IzdYVpRwMG/mq8KWOaoOdyY617P5ivaDiMCGOFDWD2sAn5Q0mR3mRtUOgm99hL9Q==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~7.13.0"
+                "undici-types": "~7.14.0"
             }
         },
         "node_modules/@types/unist": {
@@ -1631,17 +1634,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.45.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.45.0.tgz",
-            "integrity": "sha512-HC3y9CVuevvWCl/oyZuI47dOeDF9ztdMEfMH8/DW/Mhwa9cCLnK1oD7JoTVGW/u7kFzNZUKUoyJEqkaJh5y3Wg==",
+            "version": "8.46.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.46.1.tgz",
+            "integrity": "sha512-rUsLh8PXmBjdiPY+Emjz9NX2yHvhS11v0SR6xNJkm5GM1MO9ea/1GoDKlHHZGrOJclL/cZ2i/vRUYVtjRhrHVQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.45.0",
-                "@typescript-eslint/type-utils": "8.45.0",
-                "@typescript-eslint/utils": "8.45.0",
-                "@typescript-eslint/visitor-keys": "8.45.0",
+                "@typescript-eslint/scope-manager": "8.46.1",
+                "@typescript-eslint/type-utils": "8.46.1",
+                "@typescript-eslint/utils": "8.46.1",
+                "@typescript-eslint/visitor-keys": "8.46.1",
                 "graphemer": "^1.4.0",
                 "ignore": "^7.0.0",
                 "natural-compare": "^1.4.0",
@@ -1655,7 +1658,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.45.0",
+                "@typescript-eslint/parser": "^8.46.1",
                 "eslint": "^8.57.0 || ^9.0.0",
                 "typescript": ">=4.8.4 <6.0.0"
             }
@@ -1671,16 +1674,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.45.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.45.0.tgz",
-            "integrity": "sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ==",
+            "version": "8.46.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.1.tgz",
+            "integrity": "sha512-6JSSaBZmsKvEkbRUkf7Zj7dru/8ZCrJxAqArcLaVMee5907JdtEbKGsZ7zNiIm/UAkpGUkaSMZEXShnN2D1HZA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.45.0",
-                "@typescript-eslint/types": "8.45.0",
-                "@typescript-eslint/typescript-estree": "8.45.0",
-                "@typescript-eslint/visitor-keys": "8.45.0",
+                "@typescript-eslint/scope-manager": "8.46.1",
+                "@typescript-eslint/types": "8.46.1",
+                "@typescript-eslint/typescript-estree": "8.46.1",
+                "@typescript-eslint/visitor-keys": "8.46.1",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -1696,14 +1699,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.45.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.45.0.tgz",
-            "integrity": "sha512-3pcVHwMG/iA8afdGLMuTibGR7pDsn9RjDev6CCB+naRsSYs2pns5QbinF4Xqw6YC/Sj3lMrm/Im0eMfaa61WUg==",
+            "version": "8.46.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.46.1.tgz",
+            "integrity": "sha512-FOIaFVMHzRskXr5J4Jp8lFVV0gz5ngv3RHmn+E4HYxSJ3DgDzU7fVI1/M7Ijh1zf6S7HIoaIOtln1H5y8V+9Zg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.45.0",
-                "@typescript-eslint/types": "^8.45.0",
+                "@typescript-eslint/tsconfig-utils": "^8.46.1",
+                "@typescript-eslint/types": "^8.46.1",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -1718,14 +1721,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.45.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.45.0.tgz",
-            "integrity": "sha512-clmm8XSNj/1dGvJeO6VGH7EUSeA0FMs+5au/u3lrA3KfG8iJ4u8ym9/j2tTEoacAffdW1TVUzXO30W1JTJS7dA==",
+            "version": "8.46.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.46.1.tgz",
+            "integrity": "sha512-weL9Gg3/5F0pVQKiF8eOXFZp8emqWzZsOJuWRUNtHT+UNV2xSJegmpCNQHy37aEQIbToTq7RHKhWvOsmbM680A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.45.0",
-                "@typescript-eslint/visitor-keys": "8.45.0"
+                "@typescript-eslint/types": "8.46.1",
+                "@typescript-eslint/visitor-keys": "8.46.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1736,9 +1739,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.45.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.45.0.tgz",
-            "integrity": "sha512-aFdr+c37sc+jqNMGhH+ajxPXwjv9UtFZk79k8pLoJ6p4y0snmYpPA52GuWHgt2ZF4gRRW6odsEj41uZLojDt5w==",
+            "version": "8.46.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.1.tgz",
+            "integrity": "sha512-X88+J/CwFvlJB+mK09VFqx5FE4H5cXD+H/Bdza2aEWkSb8hnWIQorNcscRl4IEo1Cz9VI/+/r/jnGWkbWPx54g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1753,15 +1756,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.45.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.45.0.tgz",
-            "integrity": "sha512-bpjepLlHceKgyMEPglAeULX1vixJDgaKocp0RVJ5u4wLJIMNuKtUXIczpJCPcn2waII0yuvks/5m5/h3ZQKs0A==",
+            "version": "8.46.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.46.1.tgz",
+            "integrity": "sha512-+BlmiHIiqufBxkVnOtFwjah/vrkF4MtKKvpXrKSPLCkCtAp8H01/VV43sfqA98Od7nJpDcFnkwgyfQbOG0AMvw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.45.0",
-                "@typescript-eslint/typescript-estree": "8.45.0",
-                "@typescript-eslint/utils": "8.45.0",
+                "@typescript-eslint/types": "8.46.1",
+                "@typescript-eslint/typescript-estree": "8.46.1",
+                "@typescript-eslint/utils": "8.46.1",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^2.1.0"
             },
@@ -1778,9 +1781,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.45.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.45.0.tgz",
-            "integrity": "sha512-WugXLuOIq67BMgQInIxxnsSyRLFxdkJEJu8r4ngLR56q/4Q5LrbfkFRH27vMTjxEK8Pyz7QfzuZe/G15qQnVRA==",
+            "version": "8.46.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.1.tgz",
+            "integrity": "sha512-C+soprGBHwWBdkDpbaRC4paGBrkIXxVlNohadL5o0kfhsXqOC6GYH2S/Obmig+I0HTDl8wMaRySwrfrXVP8/pQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1792,16 +1795,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.45.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.45.0.tgz",
-            "integrity": "sha512-GfE1NfVbLam6XQ0LcERKwdTTPlLvHvXXhOeUGC1OXi4eQBoyy1iVsW+uzJ/J9jtCz6/7GCQ9MtrQ0fml/jWCnA==",
+            "version": "8.46.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.1.tgz",
+            "integrity": "sha512-uIifjT4s8cQKFQ8ZBXXyoUODtRoAd7F7+G8MKmtzj17+1UbdzFl52AzRyZRyKqPHhgzvXunnSckVu36flGy8cg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.45.0",
-                "@typescript-eslint/tsconfig-utils": "8.45.0",
-                "@typescript-eslint/types": "8.45.0",
-                "@typescript-eslint/visitor-keys": "8.45.0",
+                "@typescript-eslint/project-service": "8.46.1",
+                "@typescript-eslint/tsconfig-utils": "8.46.1",
+                "@typescript-eslint/types": "8.46.1",
+                "@typescript-eslint/visitor-keys": "8.46.1",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
@@ -1847,16 +1850,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.45.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.45.0.tgz",
-            "integrity": "sha512-bxi1ht+tLYg4+XV2knz/F7RVhU0k6VrSMc9sb8DQ6fyCTrGQLHfo7lDtN0QJjZjKkLA2ThrKuCdHEvLReqtIGg==",
+            "version": "8.46.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.46.1.tgz",
+            "integrity": "sha512-vkYUy6LdZS7q1v/Gxb2Zs7zziuXN0wxqsetJdeZdRe/f5dwJFglmuvZBfTUivCtjH725C1jWCDfpadadD95EDQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.7.0",
-                "@typescript-eslint/scope-manager": "8.45.0",
-                "@typescript-eslint/types": "8.45.0",
-                "@typescript-eslint/typescript-estree": "8.45.0"
+                "@typescript-eslint/scope-manager": "8.46.1",
+                "@typescript-eslint/types": "8.46.1",
+                "@typescript-eslint/typescript-estree": "8.46.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1871,13 +1874,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.45.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.45.0.tgz",
-            "integrity": "sha512-qsaFBA3e09MIDAGFUrTk+dzqtfv1XPVz8t8d1f0ybTzrCY7BKiMC5cjrl1O/P7UmHsNyW90EYSkU/ZWpmXelag==",
+            "version": "8.46.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.46.1.tgz",
+            "integrity": "sha512-ptkmIf2iDkNUjdeu2bQqhFPV1m6qTnFFjg7PPDjxKWaMaP0Z6I9l30Jr3g5QqbZGdw8YdYvLp+XnqnWWZOg/NA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.45.0",
+                "@typescript-eslint/types": "8.46.1",
                 "eslint-visitor-keys": "^4.2.1"
             },
             "engines": {
@@ -2621,25 +2624,24 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.36.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.36.0.tgz",
-            "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
+            "version": "9.38.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.38.0.tgz",
+            "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
-                "@eslint/config-array": "^0.21.0",
-                "@eslint/config-helpers": "^0.3.1",
-                "@eslint/core": "^0.15.2",
+                "@eslint/config-array": "^0.21.1",
+                "@eslint/config-helpers": "^0.4.1",
+                "@eslint/core": "^0.16.0",
                 "@eslint/eslintrc": "^3.3.1",
-                "@eslint/js": "9.36.0",
-                "@eslint/plugin-kit": "^0.3.5",
+                "@eslint/js": "9.38.0",
+                "@eslint/plugin-kit": "^0.4.0",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@humanwhocodes/retry": "^0.4.2",
                 "@types/estree": "^1.0.6",
-                "@types/json-schema": "^7.0.15",
                 "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.6",
@@ -2682,14 +2684,14 @@
             }
         },
         "node_modules/eslint-plugin-perfectionist": {
-            "version": "4.15.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-4.15.0.tgz",
-            "integrity": "sha512-pC7PgoXyDnEXe14xvRUhBII8A3zRgggKqJFx2a82fjrItDs1BSI7zdZnQtM2yQvcyod6/ujmzb7ejKPx8lZTnw==",
+            "version": "4.15.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-4.15.1.tgz",
+            "integrity": "sha512-MHF0cBoOG0XyBf7G0EAFCuJJu4I18wy0zAoT1OHfx2o6EOx1EFTIzr2HGeuZa1kDcusoX0xJ9V7oZmaeFd773Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "^8.34.1",
-                "@typescript-eslint/utils": "^8.34.1",
+                "@typescript-eslint/types": "^8.38.0",
+                "@typescript-eslint/utils": "^8.38.0",
                 "natural-orderby": "^5.0.0"
             },
             "engines": {
@@ -5050,9 +5052,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.9.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-            "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "devOptional": true,
             "license": "Apache-2.0",
             "bin": {
@@ -5064,16 +5066,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.45.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.45.0.tgz",
-            "integrity": "sha512-qzDmZw/Z5beNLUrXfd0HIW6MzIaAV5WNDxmMs9/3ojGOpYavofgNAAD/nC6tGV2PczIi0iw8vot2eAe/sBn7zg==",
+            "version": "8.46.1",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.46.1.tgz",
+            "integrity": "sha512-VHgijW803JafdSsDO8I761r3SHrgk4T00IdyQ+/UsthtgPRsBWQLqoSxOolxTpxRKi1kGXK0bSz4CoAc9ObqJA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.45.0",
-                "@typescript-eslint/parser": "8.45.0",
-                "@typescript-eslint/typescript-estree": "8.45.0",
-                "@typescript-eslint/utils": "8.45.0"
+                "@typescript-eslint/eslint-plugin": "8.46.1",
+                "@typescript-eslint/parser": "8.46.1",
+                "@typescript-eslint/typescript-estree": "8.46.1",
+                "@typescript-eslint/utils": "8.46.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5095,9 +5097,9 @@
             "license": "MIT"
         },
         "node_modules/undici-types": {
-            "version": "7.13.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.13.0.tgz",
-            "integrity": "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==",
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.14.0.tgz",
+            "integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==",
             "devOptional": true,
             "license": "MIT"
         },

--- a/package.json
+++ b/package.json
@@ -54,14 +54,14 @@
         "@remotex-labs/xansi": "^1.3.3"
     },
     "devDependencies": {
-        "eslint": "^9.35.0",
+        "eslint": "^9.38.0",
         "markdownlint-cli": "^0.45.0",
-        "typescript-eslint": "^8.45.0",
+        "typescript-eslint": "^8.46.1",
         "eslint-plugin-tsdoc": "^0.4.0",
-        "eslint-plugin-perfectionist": "^4.15.0",
-        "@types/node": "^24.6.1",
+        "eslint-plugin-perfectionist": "^4.15.1",
+        "@types/node": "^24.8.1",
         "@viteplus/versions": "^2.0.2",
-        "@remotex-labs/xjet": "^1.1.1",
+        "@remotex-labs/xjet": "^1.3.4",
         "@remotex-labs/xbuild": "1.6.0"
     },
     "peerDependencies": {


### PR DESCRIPTION
Fix peer dependency warning for VitePress 2.x

Updated `peerDependencies` to support both VitePress 1.6.4+ and 2.x versions, resolving installation warnings when using VitePress 2.0.0-alpha.12 on pnpm.

Fixes #9