### PR TITLE
state-model: add `getLanguageOnly` for support language+region like `…

### DIFF
--- a/src/models/state-model.spec.ts
+++ b/src/models/state-model.spec.ts
@@ -77,4 +77,43 @@ describe('StateModel', () => {
         const state = new StateModel(customConfig as any);
         expect(state.vitepressConfig).toEqual({ customKey: 'customValue' });
     });
+
+    test('vitepressConfig should include non-excluded properties from configuration', () => {
+        mockExistsSync.mockReturnValue(true);
+        const customConfig = {
+            customKey: 'customValue',
+            versionsConfig: {
+                current: 'latest',
+                sources: 'src',
+                archive: 'archive',
+                hooks: {
+                    rewritesHook: () => ''
+                },
+                versionSwitcher: {
+                    text: 'Switch Version',
+                    includeCurrentVersion: true
+                }
+            }
+        };
+
+        const state = new StateModel(customConfig as any);
+        expect(state.vitepressConfig).toEqual({ customKey: 'customValue' });
+    });
+
+    test('getLanguageOnly should extract language code from locale string', () => {
+        mockExistsSync.mockReturnValue(true);
+        const state = new StateModel();
+
+        // Test with hyphen separator
+        expect((state as any).getLanguageOnly('en-US')).toBe('en');
+
+        // Test with underscore separator
+        expect((state as any).getLanguageOnly('fr_FR')).toBe('fr');
+
+        // Test with no separator
+        expect((state as any).getLanguageOnly('de')).toBe('de');
+
+        // Test with complex locale
+        expect((state as any).getLanguageOnly('zh-Hans-CN')).toBe('zh');
+    });
 });

--- a/src/models/state.model.ts
+++ b/src/models/state.model.ts
@@ -247,6 +247,39 @@ export class StateModel {
     }
 
     /**
+     * Extracts the language code from a locale string.
+     *
+     * @param locale - A locale string in the format `language[-_]REGION`
+     *   (e.g., `"en-US"`, `"en_GB"`, `"fr"`, `"de-DE"`).
+     *
+     * @returns The language portion of the locale string, extracted by splitting on
+     * hyphens (`-`) or underscores (`_`) and returning the first segment.
+     *
+     * @remarks
+     * - This function uses a regex split pattern `/[-_]/` to handle both hyphen and
+     *   underscore separators, which are common in locale strings.
+     * - If the input locale does not contain a separator, the entire string is returned.
+     * - The function always returns the language code in its original case.
+     * - Use this when you need to normalize or compare locale strings based on their
+     *   language component only, ignoring region or script information.
+     *
+     * @example
+     * ```ts
+     * getLanguageOnly("en-US");  // → "en"
+     * getLanguageOnly("fr_FR");  // → "fr"
+     * getLanguageOnly("de");     // → "de"
+     * getLanguageOnly("zh-Hans-CN"); // → "zh"
+     * ```
+     *
+     * @see parseLocale
+     * @since 2.0.4
+     */
+
+    getLanguageOnly(locale: string): string {
+        return locale.split(/[-_]/)[0];
+    }
+
+    /**
      * Initializes the locale entries in the VitePress configuration and builds a mapping
      * of locales to their links for all versions.
      *
@@ -271,7 +304,7 @@ export class StateModel {
             const rootLocaleKey = 'root' in userLocales ? 'root' : keys[0];
 
             for (const key of keys) {
-                const index = userLocales[key].lang ?? key;
+                const index = this.getLanguageOnly(userLocales[key].lang ?? key);
                 for (const version of this.versionsList) {
                     if(key === rootLocaleKey) continue;
                     const versionPath = posix.join(index, version);


### PR DESCRIPTION
support language+region, see #12 