### PR TITLE
Honor custom sources and archive directory names in rewrites

### DIFF
--- a/docs/archive/v1.0.x/guide/index.md
+++ b/docs/archive/v1.0.x/guide/index.md
@@ -1,67 +1,77 @@
-# @viteplus/versions
+# Getting Started with @viteplus/versions
 
-A plugin for VitePress that enables versioned documentation,
-including automatic versioned routes, sidebars, navigation, and a version switcher component.
+A plugin for VitePress that enables versioned documentation, including automatic versioned
+routes, sidebars, navigation, and a version switcher component.
 
-> This is based on same API like [vitepress-versioning-plugin](https://github.com/IMB11/vitepress-versioning-plugin)
+::: info
+This line follows the same API as
+[vitepress-versioning-plugin](https://github.com/IMB11/vitepress-versioning-plugin).
+:::
 
 ## Installation
 
 Install the plugin using your preferred package manager:
 
-```bash
-pnpm install @viteplus/versions
-# or
+::: code-group
+
+```bash [npm]
 npm install @viteplus/versions
-# or
+```
+
+```bash [pnpm]
+pnpm add @viteplus/versions
+```
+
+```bash [yarn]
 yarn add @viteplus/versions
 ```
+
+:::
 
 ## Basic Setup
 
 ### Ensure Relative Links
 
-All links in your `markdown` files must be relative.
-This is critical because the plugin relies on relative paths to determine the correct versioned file to link to.
+All links in your markdown files must be relative. The plugin relies on relative paths to
+resolve the correct versioned file.
 
-Example: Linking docs/guide/advanced-setup.md from docs/guide/getting-started.md:
+Linking `docs/guide/advanced-setup.md` from `docs/guide/getting-started.md`:
 
 ```text
 ./advanced-setup.md
 ```
 
-Example: Linking docs/help/faq.md from docs/guide/getting-started.md:
+Linking `docs/help/faq.md` from `docs/guide/getting-started.md`:
 
 ```text
 ../help/faq.md
 ```
 
-> [!CAUTION]
-> Absolute links like /guide/getting-started will break versioned navigation.
+::: danger
+Absolute links such as `/guide/getting-started` break versioned navigation.
+:::
 
 ### Configure Versioning
 
-Replace defineConfig in .vitepress/config.ts with defineVersionedConfig:
+Replace `defineConfig` in `.vitepress/config.ts` with `defineVersionedConfig`:
 
 ```ts
 import { defineVersionedConfig } from '@viteplus/versions';
 
 export default defineVersionedConfig({
-    root: 'docs', // root folder 
+    root: 'docs', // root folder
     title: 'SomeProject',
-    base: '/SomeProject/', // in case github page that have prefix 
+    base: '/SomeProject/', // for GitHub Pages, which serves under a prefix
     srcDir: 'src',
     versioning: {
-        latestVersion: '1.0.0',
+        latestVersion: '1.0.0'
     }
 });
 ```
 
 ### Version Switcher Component
 
-To use a custom version switcher component:
-
-Import and register it in your theme config:
+To use a custom version switcher, register it in your theme config:
 
 ```ts
 /**
@@ -97,34 +107,38 @@ export default {
 } satisfies Theme;
 ```
 
-Add it to your navbar:
+Then add it to your navbar:
 
 ```ts
 themeConfig: {
-  versionSwitcher: false, // hide default switcher
-  nav: [
-    ...,
-    {
-      component: 'VersionSwitcher', // [!code focus]
-    },
-  ]
+    versionSwitcher: false, // hide the default switcher
+    nav: [
+        // ...
+        {
+            component: 'VersionSwitcher' // [!code focus]
+        }
+    ]
 }
 ```
 
-## Troubleshooting:
+## Troubleshooting
 
-Sidebar Cannot Be an Array:
+### The sidebar cannot be an array
 
 ```ts
 // ❌ Incorrect
 sidebar: [
-  { text: '1.0.0', link: '/' },
+    { text: '1.0.0', link: '/' }
 ]
 
 // ✅ Correct
 sidebar: {
-  '/': [
-    { text: '1.0.0', link: '/' },
-  ]
+    '/': [
+        { text: '1.0.0', link: '/' }
+    ]
 }
 ```
+
+## See also
+
+- [Release Notes](../release)

--- a/docs/archive/v1.0.x/release.md
+++ b/docs/archive/v1.0.x/release.md
@@ -2,6 +2,12 @@
 
 What changed in the `v1.0.x` line of `@viteplus/versions`.
 
+::: info
+This line is archived and no longer maintained. See the current release notes for the `v2.0.x`
+line, which replaced the `versioning` block with
+[`versionsConfig`](https://viteplus.github.io/versions/guide/config/configuration).
+:::
+
 ## v1.0.0
 
 Initial release. A VitePress plugin for versioned documentation, modeled on the API of

--- a/docs/src/guide/config/configuration.md
+++ b/docs/src/guide/config/configuration.md
@@ -1,93 +1,126 @@
 # Configuration Options
 
-The `versionsConfig` option is a central part of @viteplus/versions that controls how multiple
-versions of your documentation are organized, displayed, and navigated.
-This guide explains each configuration property in detail.
-
-## Basic Structure
-
-The `versionsConfig` object has the following structure:
+`versionsConfig` is the block `defineVersionedConfig` adds on top of a normal VitePress
+configuration. It controls where your versioned content lives, how the current version is
+labelled, and how versions are switched.
 
 ```ts
-const versionsConfig = {
-    versionsConfig: {
-        current: string,
-        sources: string,
-        archive: string,
-        hooks: {
-            rewritesHook: Function
-        },
-        versionSwitcher: boolean | {
-            text: string,
-            includeCurrentVersion: boolean
-        }
-    }
-}
+// .vitepress/config.ts
+import { defineVersionedConfig } from '@viteplus/versions';
+
+export default defineVersionedConfig({
+    title: 'My Documentation',
+    versionsConfig: { // [!code focus]
+        current: 'v2.0.x', // [!code focus]
+        sources: 'src', // [!code focus]
+        archive: 'archive', // [!code focus]
+        versionSwitcher: { // [!code focus]
+            text: 'Switch Version', // [!code focus]
+            includeCurrentVersion: true // [!code focus]
+        } // [!code focus]
+    } // [!code focus]
+});
 ```
 
-## Core Properties
+## Options
 
-### `current`
+| Option               | Type                                  | Purpose                                           |
+|----------------------|---------------------------------------|---------------------------------------------------|
+| `current`            | `string`                              | Label for the live version served at the root URL |
+| `sources`            | `string`                              | Directory holding the current version's content   |
+| `archive`            | `string`                              | Directory whose subfolders are archived versions  |
+| `versionSwitcher`    | `object` or `false`                   | The version dropdown; `false` disables it         |
+| `hooks.rewritesHook` | `(source, version, locale) => string` | Maps a content file to its final URL              |
+
+Every option has a default, listed under [Defaults](#defaults).
+
+## `current`
+
+The label for the version served from `sources`. It appears at the root URL and is
+highlighted in the switcher.
 
 ```ts
-current: 'latest'  // or '2.0', 'v3', etc.
+current: 'v2.0.x'  // or 'latest', 'v3', ...
 ```
 
-- **Purpose**: Defines the currently active version of your documentation
-- **Default**: `'latest'`
-- **Usage**: This version is served at the root URL path and is highlighted in the version switcher
-- **Example**: If set to, this version becomes the primary documentation shown to users `'v2.0'`
+This is a display label, not a directory name — nothing on disk has to match it.
 
-### `sources`
+## `sources`
+
+The directory holding the current version's content, relative to the docs root.
 
 ```ts
-sources: 'src'  // or 'docs', 'content', etc.
+sources: 'src'  // or 'latest', 'content', ...
 ```
 
-- **Purpose**: Specifies the directory containing your current version's documentation files
-- **Default**: `'src'`
-- **Usage**: This is where the plugin looks for the latest version of documentation
-- **Example**: Setting this to `'docs'` would make the plugin read files from the `docs/` directory
-
-### `archive`
-
-```ts
-archive: 'archive'  // or 'versions', 'old', etc.
+```text
+docs/
+└── src/          ← sources
+    ├── index.md
+    └── guide/
 ```
 
-- **Purpose**: Defines the directory where archived versions of documentation are stored
-- **Default**: `'archive'`
-- **Usage**: Each subdirectory in this folder represents a different version of documentation
-- **Example**: With `archive: 'versions'`, your project might have `versions/v1.0/`, `versions/v1.5/`, etc.
+## `archive`
 
-## Advanced Configuration
-
-### `hooks`
-
-[Rewrites](./rewrites) - Customize the `rewrites` routes
-
-### `versionSwitcher`
-
-[Version Switcher](../features/switchers) - Customize the version switcher component
-
-## Default Configuration
-
-@viteplus/versions comes with sensible defaults:
+The directory whose subfolders are treated as archived versions. Each subfolder name becomes
+that version's URL prefix and its key in the per-version [`nav`](../features/navigation) and
+[`sidebar`](./sidebar) maps.
 
 ```ts
-const config = {
+archive: 'archive'  // or 'versions', 'old', ...
+```
+
+```text
+docs/
+└── archive/      ← archive
+    ├── v1.0.x/   → /v1.0.x/
+    └── v1.5.x/   → /v1.5.x/
+```
+
+The directory is created for you, with a `.gitkeep`, if it does not exist.
+
+::: tip Directory names never reach the URL
+`sources` and `archive` are filesystem locations only. Whatever you name them, the current
+version is served at the root and archived versions at `/<subfolder>/`. With
+`sources: 'latest'` the home page is still `/`, not `/latest/`.
+:::
+
+The version switcher builds its list from the `archive` subfolders plus `current`, so
+renaming either directory needs no further configuration.
+
+## `hooks`
+
+See [URL Path Rewrites](./rewrites) for customizing how content files map to URLs.
+
+## `versionSwitcher`
+
+See [Version Switcher](../features/switchers) for the dropdown and the `VersionSwitcher`
+component.
+
+## Defaults
+
+Anything you omit falls back to:
+
+```ts
+const defaultConfiguration = {
     versionsConfig: {
         current: 'latest',
         sources: 'src',
         archive: 'archive',
         hooks: {
-            rewritesHook: rewritesHook  // Default implementation
+            rewritesHook: rewritesHook
         },
         versionSwitcher: {
             text: 'Switch Version',
             includeCurrentVersion: true
         }
     }
-}
-
+};
 ```
+
+## See also
+
+- [Getting Started](../)
+- [URL Path Rewrites](./rewrites)
+- [Sidebar](./sidebar)
+- [Version Switcher](../features/switchers)

--- a/docs/src/guide/config/rewrites.md
+++ b/docs/src/guide/config/rewrites.md
@@ -1,48 +1,83 @@
 # URL Path Rewrites
 
-When managing multiple versions and locales of documentation,
-having a consistent and logical URL structure is critical.
-@viteplus/versions provides a powerful path rewriting system that controls how file paths map to URLs.
+Rewrites map a content file on disk to the URL a reader sees. @viteplus/versions builds
+VitePress's `rewrites` for you from the version and locale it detects in each path, and lets
+you override the final shape through a hook.
 
-## Understanding Path Rewrites
-
-Path rewriting is the process of transforming:
-
-1. A source file path in your project
-2. Into a URL path that users see in the browser
-
-This is especially important for versioned documentation where you need to balance:
-
-- Clean URLs for users
-- Logical file organization in your codebase
-- Proper handling of multiple versions and languages
-
-## How Rewriting Works in @viteplus/versions
-
-The rewriting system uses a special hook function that transforms paths based on three `components`:
+## How a path is resolved
 
 ```text
-source → rewritesHook(source, version, locale) → final URL
+src/de/guide/intro.md → rewritesHook('guide/intro.md', '', 'de') → de/guide/intro
 ```
 
-Where:
+Three things happen before your hook runs:
 
-- `source`: The original file path (e.g., ) `guide/intro.md`
-- `version`: The documentation version (e.g., ) `v2.0.0`
-- `locale`: The language locale (e.g., `en`)
+1. The [`sources`](./configuration#sources) or [`archive`](./configuration#archive) directory
+   name is stripped from the front of the path.
+2. For an archived file, the leading version segment is taken as `version`. Current-version
+   files get an empty `version`, which is why they land at the root.
+3. The next segment is taken as `locale` if it matches a configured locale. The root locale
+   resolves to an empty string.
 
-## Default Behavior
+Whatever is left is passed as `source`.
 
-By default, @viteplus/versions uses a path structure of `locale/version/source`:
+::: tip
+Because step 1 uses your configured directory names, renaming `sources` or `archive` does not
+change any URL.
+:::
+
+## The hook
 
 ```ts
-// Default rewritesHook implementation
-function rewritesHook(source, version, locale) {
-  return join(locale, version, source);
+// Default implementation
+function rewritesHook(source: string, version: string, locale: string): string {
+    return join(locale, version, source);
 }
 ```
 
-This creates URLs like:
+| Argument  | Example          | Meaning                                                  |
+|-----------|------------------|----------------------------------------------------------|
+| `source`  | `guide/intro.md` | The path with directory, version, and locale removed     |
+| `version` | `v2.0.0`         | Archived version, or `''` for the current version        |
+| `locale`  | `de`             | Configured locale, or `''` for the root locale           |
 
-- `/en/v2.0.0/guide/introduction`
-- `/fr/v1.0.0/api/reference`
+Default output, given `sources: 'src'`, `archive: 'archive'`, and a root locale of `en`:
+
+| File                                | URL                     |
+|-------------------------------------|-------------------------|
+| `src/en/guide/intro.md`             | `/guide/intro`          |
+| `src/de/guide/intro.md`             | `/de/guide/intro`       |
+| `archive/v1.0.0/en/guide/intro.md`  | `/v1.0.0/guide/intro`   |
+| `archive/v1.0.0/de/guide/intro.md`  | `/de/v1.0.0/guide/intro`|
+
+## Customizing the structure
+
+Return a different order to put the version ahead of the locale:
+
+```ts
+export default defineVersionedConfig({
+    versionsConfig: {
+        hooks: { // [!code focus]
+            rewritesHook: (source, version, locale) => join(version, locale, source) // [!code focus]
+        } // [!code focus]
+    }
+});
+```
+
+That turns `/de/v1.0.0/guide/intro` into `/v1.0.0/de/guide/intro`.
+
+::: warning
+`version` is empty for the current version, and `locale` is empty for the root locale. Join
+the segments rather than interpolating them, so empty values do not leave stray slashes in
+the URL.
+:::
+
+Current-version files that carry no locale prefix — every file on a site with no `locales`
+configured — are served at their own path and never reach the hook. The hook shapes versioned
+and localized URLs; it cannot rewrite an unversioned, unlocalized site.
+
+## See also
+
+- [Configuration Options](./configuration)
+- [Localization](../features/locales)
+- [Getting Started](../)

--- a/docs/src/guide/config/sidebar.md
+++ b/docs/src/guide/config/sidebar.md
@@ -1,42 +1,96 @@
 # Sidebar Configuration
 
-The sidebar is a critical navigation element that helps users find content within each version of your documentation.
-With @viteplus/versions, you can create version-specific sidebars or use a single sidebar for all versions.
+The sidebar helps readers find content within a version. @viteplus/versions lets you share one
+sidebar across every version, or give each version its own.
 
-## The `skipVersioning` Flag
+## Shared sidebar (array)
 
-In @viteplus/versions, each sidebar item can include a special property: . `skipVersioning: true`
+An array applies the same sidebar to all versions, with version prefixes added to each link:
+
+```ts
+themeConfig: {
+    sidebar: [
+        { text: 'Guide', link: '/' },
+        { text: 'Log', link: '/log' },
+        {
+            text: 'Configuration',
+            collapsed: false,
+            items: [
+                { text: 'CLI Options', link: '/configuration/cli' },
+                { text: 'Configuration File', link: '/configuration/file' }
+            ]
+        }
+    ]
+}
+```
+
+## Version-specific sidebars (object)
+
+Key the object by version. `root` is the current version; each archived version uses its
+[`archive`](./configuration#archive) subfolder name as the key:
 
 ```ts
 themeConfig: {
     sidebar: {
         root: [
-            { text: 'Guide', link: '/', skipVersioning: true },
+            { text: 'Guide', link: '/' },
+            { text: 'Log', link: '/log' },
+            {
+                text: 'Configuration',
+                collapsed: false,
+                items: [
+                    { text: 'CLI Options', link: '/configuration/cli' },
+                    { text: 'Configuration File', link: '/configuration/file' }
+                ]
+            }
+        ],
+        'v1.0': [
+            { text: 'Guide', link: '/' },
+            { text: 'Legacy Log', link: '/log' },
+            { text: 'Legacy Config', link: '/legacy-config' }
+        ]
+    }
+}
+```
+
+::: danger Important
+Version-specific entries do not inherit from `root`. Each key must be a complete tree.
+:::
+
+## The `skipVersioning` flag
+
+Any sidebar item can set `skipVersioning: true` to opt out of version prefixing:
+
+```ts
+themeConfig: {
+    sidebar: {
+        root: [
+            { text: 'Guide', link: '/', skipVersioning: true }, // [!code focus]
             { text: 'Log', link: '/log' }
         ]
     }
 }
-
 ```
 
-When this flag is set:
+The link is then left exactly as written, whichever version the reader is on. Use it for links
+that must always point at the same page.
 
-- The link will **not** be processed by the versioning system
-- The link will remain unchanged regardless of which version the user is viewing
-- This is useful for external links or links that should always point to the same location
+::: tip
+External links starting with `http` are left alone automatically — no flag needed.
+:::
 
-> [!IMPORTANT]
-> If you don't include `skipVersioning: true`, links will be automatically processed to include the current version in the URL path.
+Without the flag, a link is rewritten to include the current version path.
 
-### Parent-Child Versioning Behavior
+### Nested items
 
-When working with nested sidebar items, it's important to understand how versioning applies:
+On a group, the version prefix is applied to the group's `base`, which carries down to every
+child link:
 
 ```ts
 const sidebar = {
     text: 'Configuration',
     collapsed: false,
-    base: '/configuration/',  // The version will be added here
+    base: '/configuration/',  // the version is added here
     items: [
         { text: 'CLI Options', link: '/configuration/cli' },
         { text: 'Configuration File', link: '/configuration/file' }
@@ -44,71 +98,12 @@ const sidebar = {
 };
 ```
 
-> In nested structures:
->
-> 1. The `skipVersioning` flag only needs to be set on the parent item
-> 2. All child items inherit this behavior automatically
-> 3. Version path prefixes are added to the `base` property, which affects all child links
-> 4. Setting on individual child items has no effect when the parent uses this flag `skipVersioning: true`
+So `skipVersioning` belongs on the parent only. Children inherit it, and setting it on a child
+of a flagged parent has no effect.
 
-::: danger :rocket: Important
-Setting on individual child items has no effect `skipVersioning: true` it set by the parent!
-:::
+## See also
 
-## Sidebar Configuration Options
-
-### 1. Global Sidebar (Array Format)
-
-You can define a single sidebar configuration that
-applies to all versions by using an array:
-
-```ts
-themeConfig: {
-  sidebar: [
-    { text: 'Guide', link: '/' },
-    { text: 'Log', link: '/log' },
-    {
-      text: 'Configuration',
-      collapsed: false,
-      items: [
-        { text: 'CLI Options', link: '/configuration/cli' },
-        { text: 'Configuration File', link: '/configuration/file' }
-      ]
-    }
-  ]
-}
-```
-
-> This format applies the same sidebar to all documentation versions.
-
-### 2. Version-specific Sidebars (Object Format)
-
-For more flexibility, you can define different sidebar items for specific versions using an object format:
-
-::: danger :rocket: Important
-Version-specific configurations do not inherit properties from the root configuration
-:::
-
-```ts
-themeConfig: {
-  sidebar: {
-    root: [
-      { text: 'Guide', link: '/' },
-      { text: 'Log', link: '/log' },
-      {
-        text: 'Configuration',
-        collapsed: false,
-        items: [
-          { text: 'CLI Options', link: '/configuration/cli' },
-          { text: 'Configuration File', link: '/configuration/file' }
-        ]
-      }
-    ],
-    'v1.0': [
-      { text: 'Guide', link: '/' },
-      { text: 'Legacy Log', link: '/log' },
-      { text: 'Legacy Config', link: '/legacy-config' }
-    ]
-  }
-}
-```
+- [Configuration Options](./configuration)
+- [Navigation](../features/navigation)
+- [URL Path Rewrites](./rewrites)
+- [Getting Started](../)

--- a/docs/src/guide/features/locales.md
+++ b/docs/src/guide/features/locales.md
@@ -31,6 +31,12 @@ archive/
 > Each locale has its own folder, and all documentation files for that language should be placed in that folder.
 > This structure applies to both current (`src/`) and archived versions.
 
+::: tip
+`src/` and `archive/` above are the defaults. If you renamed them with
+[`sources`](../config/configuration#sources) or [`archive`](../config/configuration#archive),
+use your own names — the locale layout inside them is the same, and the URLs are unaffected.
+:::
+
 ## Locale Configuration
 
 Locales are configured in your VitePress configuration file:
@@ -265,7 +271,10 @@ For example:
 - `/en/v2.0/guide/` - English documentation for version 2.0
 - `/de/v1.0/guide/` - German documentation for version 1.0
 
-The default locale (root) might omit the locale part:
+The root locale and the current version are both served without a segment of their own, so the
+English v2.0 guide above is reachable at `/guide/` when `en` is the root locale and `v2.0` is
+[`current`](../config/configuration#current). Override the order with
+[`rewritesHook`](../config/rewrites).
 
 ## Version-Specific Locale Configuration
 
@@ -296,3 +305,11 @@ const locales = {
 ```
 
 This allows complete customization of navigation and sidebar for each combination of locale and version.
+
+## See also
+
+- [Configuration Options](../config/configuration)
+- [URL Path Rewrites](../config/rewrites)
+- [Navigation](./navigation)
+- [Sidebar](../config/sidebar)
+- [Getting Started](../)

--- a/docs/src/guide/features/navigation.md
+++ b/docs/src/guide/features/navigation.md
@@ -1,81 +1,72 @@
 # Navigation Configuration
 
-When using @viteplus/versions, the navigation configuration
-provides special features to support version-specific navigation items.
-This allows you to customize the navigation bar based on the documentation version the user is viewing.
+The nav bar accepts the same two forms as the [sidebar](../config/sidebar): one shared array,
+or an object keyed by version.
 
-## The `skipVersioning` Flag
-
-In @viteplus/versions, each navigation item can include a special property: . `skipVersioning: true`
-
-```ts
-const navItem = { 
-    text: 'GitHub', 
-    link: 'https://github.com/viteplus/versions', 
-    skipVersioning: true 
-}
-```
-
-When this flag is set:
-
-- The link will **not** be processed by the versioning system
-- The link will remain unchanged regardless of which version the user is viewing
-- This is useful for external links or links that should always point to the same location
-
-> [!IMPORTANT]
-> If you don't include `skipVersioning: true`, links will be automatically processed to include the current version in the URL path.
-
-## Navigation Configuration Options
-
-### Option 1: Global Navigation (Array Format)
-
-You can define a single navigation configuration that
-applies to all versions by using an array:
+## Shared navigation (array)
 
 ```ts
 themeConfig: {
-  nav: [
-    { text: 'Home', link: '/' },
-    { text: 'Guide', link: '/guide/' },
-    { text: 'API', link: '/api/' },
-    { component: 'VersionSwitcher' }  // Add version switcher component
-  ]
+    nav: [
+        { text: 'Home', link: '/' },
+        { text: 'Guide', link: '/guide/' },
+        { text: 'API', link: '/api/' },
+        { component: 'VersionSwitcher' }
+    ]
 }
 ```
 
-> With this configuration, all versions of your documentation will share the same navigation items.
+Every version shares these items, each link prefixed with the version being viewed.
 
-### Option 2: Version-specific Navigation (Object Format)
-
-For more flexibility, you can define different navigation items for specific versions using an object format:
-
-::: danger :rocket: Important
-Version-specific configurations do not inherit properties from the root configuration
-:::
+## Version-specific navigation (object)
 
 ```ts
-const themeConfig = {
-    themeConfig: {
-        nav: {
-            root: [ // Default navigation for versions without specific configuration
-                { text: 'Home', link: '/' },
-                { text: 'Guide', link: '/guide/' },
-                { text: 'API', link: '/api/' },
-                { component: 'VersionSwitcher' }
-            ],
-            'v1.0': [ // Navigation specifically for version 1.0
-                { text: 'Home', link: '/' },
-                { text: 'Access', link: '/access/' }, // Version 1.0-specific link
-                { text: 'Old API', link: '/old-api/' }, // Version 1.0-specific link
-                { component: 'VersionSwitcher' }
-            ]
-        }
+themeConfig: {
+    nav: {
+        root: [ // default for any version without its own entry
+            { text: 'Home', link: '/' },
+            { text: 'Guide', link: '/guide/' },
+            { text: 'API', link: '/api/' },
+            { component: 'VersionSwitcher' }
+        ],
+        'v1.0': [ // only for v1.0
+            { text: 'Home', link: '/' },
+            { text: 'Access', link: '/access/' },
+            { text: 'Old API', link: '/old-api/' },
+            { component: 'VersionSwitcher' }
+        ]
     }
 }
 ```
 
-> In this example:
->
-> - Versions and `v3.0` will use the navigation defined in `root` `v2.0`
-> - Version will use its own custom navigation `v1.0`
-> - The `root` configuration serves as the default for any version that doesn't have a specific configuration
+`v1.0` uses its own items; every other version falls back to `root`.
+
+::: danger Important
+Version-specific entries do not inherit from `root`. Each key must be a complete tree.
+:::
+
+## The `skipVersioning` flag
+
+Set `skipVersioning: true` on an item to leave its link untouched:
+
+```ts
+const navItem = {
+    text: 'GitHub',
+    link: 'https://github.com/viteplus/versions',
+    skipVersioning: true // [!code focus]
+};
+```
+
+::: tip
+Links starting with `http` are already left alone, so the flag is only needed for internal
+links that must always resolve to the same page.
+:::
+
+Without it, an internal link is rewritten to include the current version path.
+
+## See also
+
+- [Sidebar](../config/sidebar)
+- [Version Switcher](./switchers)
+- [Localization](./locales)
+- [Getting Started](../)

--- a/docs/src/guide/features/switchers.md
+++ b/docs/src/guide/features/switchers.md
@@ -107,3 +107,16 @@ The `VersionSwitcher` component offers significant advantages:
 3. **Responsive Design**: Adapts to both desktop and mobile viewports with appropriate styling.
 4. **Custom Styling**: Can be styled to match your theme's design system.
 5. **Dynamic Behavior**: Shows only relevant version options based on the current context.
+
+::: tip
+The version list is built from the [`archive`](../config/configuration#archive) subfolders plus
+[`current`](../config/configuration#current), so you never list versions by hand. The switcher
+stays hidden until at least one version is archived.
+:::
+
+## See also
+
+- [Configuration Options](../config/configuration)
+- [Navigation](./navigation)
+- [Localization](./locales)
+- [Getting Started](../)

--- a/docs/src/guide/index.md
+++ b/docs/src/guide/index.md
@@ -7,13 +7,21 @@ This guide will help you set up and configure the plugin for your documentation 
 
 Install the package using your preferred package manager:
 
-```bash
+::: code-group
+
+```bash [npm]
 npm install @viteplus/versions
-# or
-yarn add @viteplus/versions
-# or
+```
+
+```bash [pnpm]
 pnpm add @viteplus/versions
 ```
+
+```bash [yarn]
+yarn add @viteplus/versions
+```
+
+:::
 
 ## Basic Setup
 
@@ -62,13 +70,13 @@ Organize your documentation files following this structure:
 docs/
 ├── .vitepress/
 │   └── config.ts
-├── src/            // Current version docs
+├── src/            // Current version docs  ← sources
 │   ├── index.md
 │   ├── guide/
 │   │   └── ...
 │   └── api/
 │       └── ...
-└── archive/       // Archived versions
+└── archive/       // Archived versions      ← archive
     ├── v1.0/
     │   ├── index.md
     │   └── ...
@@ -76,6 +84,10 @@ docs/
         ├── index.md
         └── ...
 ```
+
+Both directory names are configurable through [`sources`](./config/configuration#sources) and
+[`archive`](./config/configuration#archive). They are filesystem locations only — renaming them
+does not change a single URL.
 
 ## Core Features
 
@@ -181,11 +193,12 @@ export default {
 | `versionsConfig.versionSwitcher`    | Configuration for the version switcher         |
 | `versionsConfig.hooks.rewritesHook` | Customize URL structure                        |
 
-## Examples and Guides
+## See also
 
-- [Sidebar](./config/sidebar) - Learn how to customize sidebar per version
-- [Navigation](./features/navigation) - Learn how to customize navigation per version
-- [Localization](./features/locales) - Set up multilingual documentation
-- [Version Switcher](./features/switchers) - Customize the version switcher component
-- [URL Path Rewrites](./config/rewrites) - Control how URLs are generated
-- [Version Configuration](./config/configuration) - Learn how to configure version settings
+- [Configuration Options](./config/configuration) - every `versionsConfig` option
+- [Sidebar](./config/sidebar) - customize the sidebar per version
+- [URL Path Rewrites](./config/rewrites) - control how URLs are generated
+- [Navigation](./features/navigation) - customize the nav bar per version
+- [Localization](./features/locales) - set up multilingual documentation
+- [Version Switcher](./features/switchers) - customize the switcher component
+- [Release Notes](../release) - what changed in each release

--- a/docs/src/release.md
+++ b/docs/src/release.md
@@ -3,6 +3,20 @@
 What changed in each release of `@viteplus/versions`. The current line is `v2.0.x`; for
 the previous line see [Earlier releases](#earlier-releases).
 
+## v2.0.8
+
+A fix so custom content directory names stay out of the URL.
+
+- **Fixed**: Renaming [`sources`](guide/config/configuration#sources) or
+  [`archive`](guide/config/configuration#archive) no longer prefixes every URL with the directory
+  name. Route rewriting matched the literal strings `src/` and `archive/`, so any other name fell
+  through unrewritten — `sources: 'latest'` served the home page at `/latest/` instead of `/`. Both
+  prefixes are now read from your configuration.
+- **Fixed**: A locale prefix is stripped by length rather than by substring match, so a path that
+  repeats the directory or locale name deeper in the tree is no longer mangled.
+- **Changed**: Updated `vitepress`, `eslint`, `typescript-eslint`, `eslint-plugin-perfectionist`,
+  and `@types/node` to their current releases.
+
 ## v2.0.7
 
 Packaging correctness and toolchain modernization, plus a fix so external nav links are no longer version-prefixed.

--- a/package.json
+++ b/package.json
@@ -58,17 +58,17 @@
         "docs:preview":     "vitepress preview docs"
     },
     "dependencies": {
-        "vitepress": "^2.0.0-alpha.18",
+        "vitepress": "^2.0.0-alpha.19",
         "@remotex-labs/xansi": "^1.3.7"
     },
     "devDependencies": {
-        "eslint": "^10.7.0",
+        "eslint": "^10.8.1",
         "markdownlint-cli": "^0.49.1",
-        "typescript-eslint": "^8.65.0",
+        "typescript-eslint": "^8.67.0",
         "eslint-plugin-tsdoc": "^0.5.2",
-        "eslint-plugin-perfectionist": "^5.10.0",
-        "@types/node": "^26.1.1",
-        "@viteplus/versions": "^2.0.6",
+        "eslint-plugin-perfectionist": "^5.10.1",
+        "@types/node": "^26.2.0",
+        "@viteplus/versions": "^2.0.7",
         "@remotex-labs/xjet": "^1.5.6",
         "@remotex-labs/xbuild": "^2.5.1"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.3.7
         version: 1.3.7
       vitepress:
-        specifier: ^2.0.0-alpha.18
-        version: 2.0.0-alpha.18(@types/node@26.1.1)(esbuild@0.28.1)(postcss@8.5.20)(typescript@6.0.3)
+        specifier: ^2.0.0-alpha.19
+        version: 2.0.0-alpha.19(@types/node@26.2.0)(esbuild@0.28.1)(postcss@8.5.26)(typescript@5.9.3)
     devDependencies:
       '@remotex-labs/xbuild':
         specifier: ^2.5.1
@@ -22,26 +22,26 @@ importers:
         specifier: ^1.5.6
         version: 1.5.6
       '@types/node':
-        specifier: ^26.1.1
-        version: 26.1.1
+        specifier: ^26.2.0
+        version: 26.2.0
       '@viteplus/versions':
-        specifier: ^2.0.6
-        version: 2.0.6(vitepress@2.0.0-alpha.18(@types/node@26.1.1)(esbuild@0.28.1)(postcss@8.5.20)(typescript@6.0.3))
+        specifier: ^2.0.7
+        version: 2.0.7(vitepress@2.0.0-alpha.19(@types/node@26.2.0)(esbuild@0.28.1)(postcss@8.5.26)(typescript@5.9.3))
       eslint:
-        specifier: ^10.7.0
-        version: 10.7.0
+        specifier: ^10.8.1
+        version: 10.8.1
       eslint-plugin-perfectionist:
-        specifier: ^5.10.0
-        version: 5.10.0(eslint@10.7.0)(typescript@6.0.3)
+        specifier: ^5.10.1
+        version: 5.10.1(eslint@10.8.1)(typescript@5.9.3)
       eslint-plugin-tsdoc:
         specifier: ^0.5.2
-        version: 0.5.2(eslint@10.7.0)(typescript@6.0.3)
+        version: 0.5.2(eslint@10.8.1)(typescript@5.9.3)
       markdownlint-cli:
         specifier: ^0.49.1
         version: 0.49.1
       typescript-eslint:
-        specifier: ^8.65.0
-        version: 8.65.0(eslint@10.7.0)(typescript@6.0.3)
+        specifier: ^8.67.0
+        version: 8.67.0(eslint@10.8.1)(typescript@5.9.3)
 
 packages:
 
@@ -62,23 +62,14 @@ packages:
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
-  '@docsearch/css@4.6.3':
-    resolution: {integrity: sha512-nlOwcXcsNAptQl4vlL4MA78qNJKO0Qlds5GuBjCoePgkebTXLSf8Qt1oyZ3YBshYupKXG9VRGEsk1zr23d+bzQ==}
+  '@docsearch/css@4.7.0':
+    resolution: {integrity: sha512-Sk5xkdRFeE7PeWjG9l4AfTwdvMfr9wHiwNNCpHXT4v4SNyNMKdHGvEILc31BgaVFGDDNbv5u/a73tofRiwbEZw==}
 
-  '@docsearch/js@4.6.3':
-    resolution: {integrity: sha512-qUIX2b4Apew3tv4F0qhmgShsl/Lfw4m6mqv/5/5dWNxwTcDdLMp2s3YwZ+NMGh3IKCg0pBaXm7Q5VdyU5Rj+cQ==}
+  '@docsearch/js@4.7.0':
+    resolution: {integrity: sha512-x5lCqu1tetgsJFkjQ6VSocbHldsRkGEgwg5N98Vx21sq/V5wcmj4u226PY9k+TEpIgQ772zlYbPLTPicWyGnpA==}
 
-  '@docsearch/sidepanel-js@4.6.3':
-    resolution: {integrity: sha512-grGSmvXzG0if+mrzdIKykvpIAuEQ9u0sEJ2eLRRCaQfJvsWqh2C2/aY04bIzWvDh7myi5rvl8D+tUNsVrjYQ3A==}
-
-  '@emnapi/core@1.11.1':
-    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
-
-  '@emnapi/runtime@1.11.1':
-    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
-
-  '@emnapi/wasi-threads@1.2.2':
-    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+  '@docsearch/sidepanel-js@4.7.0':
+    resolution: {integrity: sha512-A8r34jCU8kcIk2viECEn2msA28ojUF1BLi/3v5OWWc5G2N3jOuuumBXoeYjfr8dA0UxgFSy5R2bt12dnFJQSyA==}
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -250,8 +241,8 @@ packages:
     resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/config-helpers@0.6.0':
-    resolution: {integrity: sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==}
+  '@eslint/config-helpers@0.7.0':
+    resolution: {integrity: sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@eslint/core@1.2.1':
@@ -282,8 +273,8 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
-  '@iconify-json/simple-icons@1.2.91':
-    resolution: {integrity: sha512-plQJHZxzpkIXaeYjJF0Sc9nkzYF32EDX9olx7j1hcKYFaiTrQXbcngZmvzuV0pG6uZPU3ZuA/GIsgxSHOm6jrQ==}
+  '@iconify-json/simple-icons@1.2.93':
+    resolution: {integrity: sha512-/XhANjfGYOuqvSR3TmUnkQkINvQ4GVjVuukvymRbxtVFBvIq/yiXJqCDycKcQPT401OYT9H2vIY6ihAlz1QIAw==}
 
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
@@ -297,14 +288,8 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
-  '@napi-rs/wasm-runtime@1.1.6':
-    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
-
-  '@oxc-project/types@0.139.0':
-    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+  '@oxc-project/types@0.143.0':
+    resolution: {integrity: sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==}
 
   '@remotex-labs/xansi@1.3.7':
     resolution: {integrity: sha512-U7pzj4bWxQF16MPGnwf9uWnxV/pyFmjppzsbCsEEEtCrBS/gAJMURkYHsLz5rW0+mT9RCA55l2BjTp9SPLYQoQ==}
@@ -332,97 +317,92 @@ packages:
     resolution: {integrity: sha512-KjVm1t5LdTrscD4aZYsGTLUHdJy+IrY1U2sAG2GMwt3xf58awxfAJjgxOl+wEpyfhfc5GNPpLnat7b+WqxECCw==}
     engines: {node: '>=20'}
 
-  '@rolldown/binding-android-arm64@1.1.5':
-    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
+  '@rolldown/binding-android-arm64@1.2.3':
+    resolution: {integrity: sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.1.5':
-    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
+  '@rolldown/binding-darwin-arm64@1.2.3':
+    resolution: {integrity: sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.1.5':
-    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
+  '@rolldown/binding-darwin-x64@1.2.3':
+    resolution: {integrity: sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.1.5':
-    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
+  '@rolldown/binding-freebsd-x64@1.2.3':
+    resolution: {integrity: sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
-    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
+    resolution: {integrity: sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.5':
-    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
+  '@rolldown/binding-linux-arm64-gnu@1.2.3':
+    resolution: {integrity: sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.1.5':
-    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
+  '@rolldown/binding-linux-arm64-musl@1.2.3':
+    resolution: {integrity: sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
-    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
+  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
+    resolution: {integrity: sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.5':
-    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
+  '@rolldown/binding-linux-s390x-gnu@1.2.3':
+    resolution: {integrity: sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.1.5':
-    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
+  '@rolldown/binding-linux-x64-gnu@1.2.3':
+    resolution: {integrity: sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.1.5':
-    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
+  '@rolldown/binding-linux-x64-musl@1.2.3':
+    resolution: {integrity: sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.1.5':
-    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
+  '@rolldown/binding-openharmony-arm64@1.2.3':
+    resolution: {integrity: sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.1.5':
-    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [wasm32]
-
-  '@rolldown/binding-win32-arm64-msvc@1.1.5':
-    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
+  '@rolldown/binding-win32-arm64-msvc@1.2.3':
+    resolution: {integrity: sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.1.5':
-    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
+  '@rolldown/binding-win32-x64-msvc@1.2.3':
+    resolution: {integrity: sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -430,43 +410,40 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  '@shikijs/core@4.3.1':
-    resolution: {integrity: sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA==}
+  '@shikijs/core@4.4.3':
+    resolution: {integrity: sha512-QCR4q2ZO/ILJEuwiBMel4wdcTDb1JGwfjKTxPDF6x8ixOaluPrVqIn06C99AcRPhmYlBR56d/Fb+GN58GzExpg==}
     engines: {node: '>=20'}
 
-  '@shikijs/engine-javascript@4.3.1':
-    resolution: {integrity: sha512-JBItcnPuYq7jVJdZo/vMj94r+szT7XEjHFX+mvFDGSEIbVAXAGyHAHzhbWzpGOwYidCZrErJLLgn2PVeiokHnQ==}
+  '@shikijs/engine-javascript@4.4.3':
+    resolution: {integrity: sha512-FbOjFJp9VLdo1Wevs10BBtVxiTWwNLqZh5Gkhjgda/ioL15YOgeSl9n+6XMa3qRlPQzfhFNe641SrynFHYG0nQ==}
     engines: {node: '>=20'}
 
-  '@shikijs/engine-oniguruma@4.3.1':
-    resolution: {integrity: sha512-OXyNMzg0pews+msMj4cHeqT4xiYKKvbnn6VbdAXxfoFl3SSx4fJTc8FadECuc5/H9p3BzhNAoAUXKwAu9rWYhg==}
+  '@shikijs/engine-oniguruma@4.4.3':
+    resolution: {integrity: sha512-EcOQkxdxGQrc1Row/cC2c96/v1dbZqGnEVu1qTuT/MJmp6+cXCvQussowVmCv5Tqr3KuY3c7IbM6HTW3LJ1k9w==}
     engines: {node: '>=20'}
 
-  '@shikijs/langs@4.3.1':
-    resolution: {integrity: sha512-m0l9nsDqgBHvbZbk7A0/kXz/impK3uB/c6rAn6Gpg/uPtdZRQ+alsN/17MU5thb68XTj/4DxkZAotrM0GGSpDQ==}
+  '@shikijs/langs@4.4.3':
+    resolution: {integrity: sha512-ePic0yfAJGOF83D5wBHK/00EjK65oahBYxFk5epgq33WRv7X9UuxLEV8PtR0szC0z8dl7INIpIodB99JRFlR+A==}
     engines: {node: '>=20'}
 
-  '@shikijs/primitive@4.3.1':
-    resolution: {integrity: sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A==}
+  '@shikijs/primitive@4.4.3':
+    resolution: {integrity: sha512-m0wBeLDQDeIxRdUmrCPdQqfuUamDwRL5isCfYbguKD6NiaKpVbsv+3J81DyIKgNW5h4WAIIr8T4EkgQrBBxvaQ==}
     engines: {node: '>=20'}
 
-  '@shikijs/themes@4.3.1':
-    resolution: {integrity: sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA==}
+  '@shikijs/themes@4.4.3':
+    resolution: {integrity: sha512-w8UHjeUnIR965KMWJHUPXOc2mNJUnK3vpVLYLvw5IYU2mnTTJ89E24OrJDBNiJDQ0qzb0tc4l7mrIXx5cFeIyw==}
     engines: {node: '>=20'}
 
-  '@shikijs/transformers@4.3.1':
-    resolution: {integrity: sha512-z6ir0bGDgWcF2FduktEfPgIsdOtIlDiLAjFBgBzE42Q9xHbkkIXZtORHzlLVB71iZP9elEcqKg6keajvOUwE2A==}
+  '@shikijs/transformers@4.4.3':
+    resolution: {integrity: sha512-oJSARV6NaWd+rnNJbtnpAdj3Zg0ZVyzsnMgb3vi3HA+35y8lBWUCpOnWsmyiXZIikY+x1BDqrQUgmxfzWh7Jvw==}
     engines: {node: '>=20'}
 
-  '@shikijs/types@4.3.1':
-    resolution: {integrity: sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g==}
+  '@shikijs/types@4.4.3':
+    resolution: {integrity: sha512-UEJxmRR++MAGR6hugn0vgVS2W/6lWAts84FFSrnlH9sP0LNol7E5+NQ792pH8liWUhyMyjhTgSUH3k7iD7tc5g==}
     engines: {node: '>=20'}
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
-
-  '@tybys/wasm-util@0.10.3':
-    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
@@ -479,6 +456,9 @@ packages:
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/hast@3.0.5':
+    resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -501,8 +481,8 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node@26.1.1':
-    resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
+  '@types/node@26.2.0':
+    resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -519,16 +499,16 @@ packages:
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
-  '@typescript-eslint/eslint-plugin@8.65.0':
-    resolution: {integrity: sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==}
+  '@typescript-eslint/eslint-plugin@8.67.0':
+    resolution: {integrity: sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.65.0
+      '@typescript-eslint/parser': ^8.67.0
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/parser@8.65.0':
-    resolution: {integrity: sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==}
+  '@typescript-eslint/parser@8.67.0':
+    resolution: {integrity: sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -546,6 +526,12 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/project-service@8.67.0':
+    resolution: {integrity: sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/scope-manager@8.56.0':
     resolution: {integrity: sha512-7UiO/XwMHquH+ZzfVCfUNkIXlp/yQjjnlYUyYz7pfvlK3/EyyN6BK+emDmGNyQLBtLGaYrTAI6KOw8tFucWL2w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -554,14 +540,12 @@ packages:
     resolution: {integrity: sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/scope-manager@8.67.0':
+    resolution: {integrity: sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/tsconfig-utils@8.56.0':
     resolution: {integrity: sha512-bSJoIIt4o3lKXD3xmDh9chZcjCz5Lk8xS7Rxn+6l5/pKrDpkCwtQNQQwZ2qRPk7TkUYhrq3WPIHXOXlbXP0itg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/tsconfig-utils@8.56.1':
-    resolution: {integrity: sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
@@ -572,8 +556,14 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/type-utils@8.65.0':
-    resolution: {integrity: sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==}
+  '@typescript-eslint/tsconfig-utils@8.67.0':
+    resolution: {integrity: sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.67.0':
+    resolution: {integrity: sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -583,12 +573,12 @@ packages:
     resolution: {integrity: sha512-DBsLPs3GsWhX5HylbP9HNG15U0bnwut55Lx12bHB9MpXxQ+R5GC8MwQe+N1UFXxAeQDvEsEDY6ZYwX03K7Z6HQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/types@8.56.1':
-    resolution: {integrity: sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@typescript-eslint/types@8.65.0':
     resolution: {integrity: sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/types@8.67.0':
+    resolution: {integrity: sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@8.56.0':
@@ -599,6 +589,12 @@ packages:
 
   '@typescript-eslint/typescript-estree@8.65.0':
     resolution: {integrity: sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/typescript-estree@8.67.0':
+    resolution: {integrity: sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -617,12 +613,23 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/utils@8.67.0':
+    resolution: {integrity: sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/visitor-keys@8.56.0':
     resolution: {integrity: sha512-q+SL+b+05Ud6LbEE35qe4A99P+htKTKVbyiNEe45eCbJFyh/HVK9QXwlrbz+Q4L8SOW4roxSVwXYj4DMBT7Ieg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/visitor-keys@8.65.0':
     resolution: {integrity: sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.67.0':
+    resolution: {integrity: sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
@@ -636,8 +643,8 @@ packages:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
 
-  '@viteplus/versions@2.0.6':
-    resolution: {integrity: sha512-13XNud+sCGTOs1L6Z0Ru7TxwkYmTknGSm/KU7/5wXR7vwMPqaPByC/A4H6R2R3aF8uK4Y1Y9bXyBQYJyYc3/Cw==}
+  '@viteplus/versions@2.0.7':
+    resolution: {integrity: sha512-NX8YVdMsxw3NqWw1GQHPgKRco7GSnPbECrRhnwQWPFhw0EutzCO2uIEuHrTitAsqMVHP6ZETAMmL+BpLr2ZKpQ==}
     engines: {node: '>=20'}
     peerDependencies:
       vitepress: ^1.6.4 || ^2.0.0
@@ -657,14 +664,14 @@ packages:
   '@vue/compiler-ssr@3.5.40':
     resolution: {integrity: sha512-rrE5xiXG663+vHCHa3J9p2z5OcBRjXmoqenprJxAFQxg5pSshzeBiCE6pu46axapRJ2Adk0YDA2BRZVjiHXnhg==}
 
-  '@vue/devtools-api@8.1.5':
-    resolution: {integrity: sha512-YJipMVAKe5wT5CWf5kTYCaNV7NMNjFVxJkIkJaJ4W/nCxEBzlZzrOsYKeCymdCrFZmBS/+wTWFoUs3Jf/Q6XSQ==}
+  '@vue/devtools-api@8.2.1':
+    resolution: {integrity: sha512-6u4vXBlIBAC1wMplIZgpyPn7uh/s4Bf6F5bMzvLv+EdJ0aHs/+4B7Ygv864EStQSjRbsRzTko/kUG1A1IejQ3A==}
 
-  '@vue/devtools-kit@8.1.5':
-    resolution: {integrity: sha512-FcSAxsi4eWuXLCB7Rv9lj0aIVHHPNVQ2BazGf4RJTc2JCqb4BQg0hk87ZFhminCfl+mD5OUI0rX2cgyu4kJOGA==}
+  '@vue/devtools-kit@8.2.1':
+    resolution: {integrity: sha512-FIGIuq3AWReEpbAHY/cRGeHDfI0qOb8OCQ3YjbEAX04uaxIDbGc9rhkbVcG7rnfHPXE3RsU5KrWOu9V/okd8AQ==}
 
-  '@vue/devtools-shared@8.1.5':
-    resolution: {integrity: sha512-mhT4zcPFhF+Xk1O4BfhhrbXzpmfqY03fS6xGpcllbQG7lDjhQf8pQHcTIhqQIYx1hfwtHmk/6jM96ele0UxPqQ==}
+  '@vue/devtools-shared@8.2.1':
+    resolution: {integrity: sha512-Fkac7lUdGReh6pVOi3AYPRGe82LQqRmAfThW7RRligOAP0ZA/Z1z9XLHDM9dv34pV2HRc79DK8uKPeG2fLnA/g==}
 
   '@vue/reactivity@3.5.40':
     resolution: {integrity: sha512-B7ot9UlUZOi1zbq61/LvE88ZLTV8IlajTdiZTAEiDQgrnIMIZoPr9kGw0Zw46ObW62O9+H/Be3kMbfb7kYPQZA==}
@@ -681,13 +688,13 @@ packages:
   '@vue/shared@3.5.40':
     resolution: {integrity: sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==}
 
-  '@vueuse/core@14.3.0':
-    resolution: {integrity: sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==}
+  '@vueuse/core@14.4.0':
+    resolution: {integrity: sha512-X4WHz1HlCzCBoYXesUkifzzWBAcZgXG8Fi5iNPQg/epdzOB3gu8Fawj3hvuwYR1nGcXGnvxwYYcUC/71++svtQ==}
     peerDependencies:
       vue: ^3.5.0
 
-  '@vueuse/integrations@14.3.0':
-    resolution: {integrity: sha512-76I5FT2ESvCmCaSwapI+a/u/CFtNXmzl9f9lNp1hRtx8vKB8hfiokJr8IvQqcQG5ckGXElyXK516b54ozV3MvA==}
+  '@vueuse/integrations@14.4.0':
+    resolution: {integrity: sha512-oJz9qTgczvA7L1nXQFRU7h8tQbOCoiceqvMMhT9XYMyOGTqLJ2rEa09PON+nD2t48sZUfeOmg4eaWJXV4sZb/w==}
     peerDependencies:
       async-validator: ^4
       axios: ^1
@@ -728,11 +735,11 @@ packages:
       universal-cookie:
         optional: true
 
-  '@vueuse/metadata@14.3.0':
-    resolution: {integrity: sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==}
+  '@vueuse/metadata@14.4.0':
+    resolution: {integrity: sha512-swx/255R6JyHZFJhx845iz5CRWDZdCfvkZOpACWc5+c5WHcG24mv8gUT1WIdFQaHt6dq79rvILd9QnCWiyVm9g==}
 
-  '@vueuse/shared@14.3.0':
-    resolution: {integrity: sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==}
+  '@vueuse/shared@14.4.0':
+    resolution: {integrity: sha512-JRgY90Sz8DDtPMsaDflvPMp9xYk69JZAmbuDvAquUVXKr2gEjqtzGNTTthLfckH0BzBqvnu31gb4a8TGLRe79g==}
     peerDependencies:
       vue: ^3.5.0
 
@@ -775,10 +782,6 @@ packages:
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
-
-  brace-expansion@5.0.2:
-    resolution: {integrity: sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==}
-    engines: {node: 20 || >=22}
 
   brace-expansion@5.0.7:
     resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
@@ -875,8 +878,8 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-plugin-perfectionist@5.10.0:
-    resolution: {integrity: sha512-HiqpDrUDbGrMC6iHQbemgDyHJ0366Vyz/qRWmxQcSAkmG25cXr8BdRgx8yAhOKhEfBXn8Rnf/mTCsV4EqUJSxg==}
+  eslint-plugin-perfectionist@5.10.1:
+    resolution: {integrity: sha512-Kprsp9Us0GqAesYaAIzUViw57xYp5WBqzXrcE0Mtww++E5fexWXYBipMuuD7yvyH4vvpBH0+oJ+OMAmZ0oYXkw==}
     engines: {node: ^20.0.0 || >=22.0.0}
     peerDependencies:
       eslint: ^8.45.0 || ^9.0.0 || ^10.0.0
@@ -896,8 +899,8 @@ packages:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  eslint@10.7.0:
-    resolution: {integrity: sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==}
+  eslint@10.8.1:
+    resolution: {integrity: sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     hasBin: true
     peerDependencies:
@@ -1010,10 +1013,6 @@ packages:
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
-    engines: {node: '>= 4'}
-
-  ignore@7.0.5:
-    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
   ignore@7.0.6:
@@ -1273,10 +1272,6 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
-  minimatch@10.2.4:
-    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
-    engines: {node: 18 || 20 || >=22}
-
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -1296,6 +1291,11 @@ packages:
 
   nanoid@3.3.16:
     resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1344,16 +1344,16 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
-
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
   postcss@8.5.20:
     resolution: {integrity: sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -1389,8 +1389,8 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
-  rolldown@1.1.5:
-    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
+  rolldown@1.2.3:
+    resolution: {integrity: sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -1411,8 +1411,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shiki@4.3.1:
-    resolution: {integrity: sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw==}
+  shiki@4.4.3:
+    resolution: {integrity: sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g==}
     engines: {node: '>=20'}
 
   smol-toml@1.7.0:
@@ -1452,10 +1452,6 @@ packages:
   tabbable@6.5.0:
     resolution: {integrity: sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==}
 
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
-
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
@@ -1463,31 +1459,27 @@ packages:
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
-  ts-api-utils@2.4.0:
-    resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
-    engines: {node: '>=18.12'}
-    peerDependencies:
-      typescript: '>=4.8.4'
-
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
 
-  tslib@2.8.1:
-    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
-
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
-  typescript-eslint@8.65.0:
-    resolution: {integrity: sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==}
+  typescript-eslint@8.67.0:
+    resolution: {integrity: sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   typescript@6.0.2:
     resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
@@ -1529,13 +1521,13 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite@8.1.5:
-    resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
+  vite@8.2.1:
+    resolution: {integrity: sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
-      '@vitejs/devtools': ^0.3.0
+      '@vitejs/devtools': ^0.4.0
       esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
@@ -1572,8 +1564,8 @@ packages:
       yaml:
         optional: true
 
-  vitepress@2.0.0-alpha.18:
-    resolution: {integrity: sha512-Lk1G2/QqSf+MwNLICl9fmzWOtoCEwjZoWgaQy41QvWTfcGpLE9XwJDbcCyES/9rj6R2g1zFqFvLVkYKLLDALFw==}
+  vitepress@2.0.0-alpha.19:
+    resolution: {integrity: sha512-WnBsb0Bwr43kXKyiis+lld/7ri3hnMbthS8N3hpFtjjwsdLO4IRmiAE08D7aud4q6oMDf9uwRowxzNqRFe/amw==}
     hasBin: true
     peerDependencies:
       markdown-it-mathjax3: ^4
@@ -1639,27 +1631,11 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@docsearch/css@4.6.3': {}
+  '@docsearch/css@4.7.0': {}
 
-  '@docsearch/js@4.6.3': {}
+  '@docsearch/js@4.7.0': {}
 
-  '@docsearch/sidepanel-js@4.6.3': {}
-
-  '@emnapi/core@1.11.1':
-    dependencies:
-      '@emnapi/wasi-threads': 1.2.2
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/runtime@1.11.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/wasi-threads@1.2.2':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
+  '@docsearch/sidepanel-js@4.7.0': {}
 
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
@@ -1739,9 +1715,9 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.7.0)':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.8.1)':
     dependencies:
-      eslint: 10.7.0
+      eslint: 10.8.1
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -1750,11 +1726,11 @@ snapshots:
     dependencies:
       '@eslint/object-schema': 3.0.5
       debug: 4.4.3
-      minimatch: 10.2.4
+      minimatch: 10.2.5
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.6.0':
+  '@eslint/config-helpers@0.7.0':
     dependencies:
       '@eslint/core': 1.2.1
 
@@ -1780,7 +1756,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@iconify-json/simple-icons@1.2.91':
+  '@iconify-json/simple-icons@1.2.93':
     dependencies:
       '@iconify/types': 2.0.0
 
@@ -1797,14 +1773,7 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
-    dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@tybys/wasm-util': 0.10.3
-    optional: true
-
-  '@oxc-project/types@0.139.0': {}
+  '@oxc-project/types@0.143.0': {}
 
   '@remotex-labs/xansi@1.3.7': {}
 
@@ -1838,106 +1807,94 @@ snapshots:
 
   '@remotex-labs/xstruct@2.1.3': {}
 
-  '@rolldown/binding-android-arm64@1.1.5':
+  '@rolldown/binding-android-arm64@1.2.3':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.1.5':
+  '@rolldown/binding-darwin-arm64@1.2.3':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.1.5':
+  '@rolldown/binding-darwin-x64@1.2.3':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.1.5':
+  '@rolldown/binding-freebsd-x64@1.2.3':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+  '@rolldown/binding-linux-arm64-gnu@1.2.3':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.1.5':
+  '@rolldown/binding-linux-arm64-musl@1.2.3':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+  '@rolldown/binding-linux-s390x-gnu@1.2.3':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.1.5':
+  '@rolldown/binding-linux-x64-gnu@1.2.3':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.1.5':
+  '@rolldown/binding-linux-x64-musl@1.2.3':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.1.5':
+  '@rolldown/binding-openharmony-arm64@1.2.3':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.1.5':
-    dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+  '@rolldown/binding-win32-arm64-msvc@1.2.3':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.1.5':
-    optional: true
-
-  '@rolldown/binding-win32-x64-msvc@1.1.5':
+  '@rolldown/binding-win32-x64-msvc@1.2.3':
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@shikijs/core@4.3.1':
+  '@shikijs/core@4.4.3':
     dependencies:
-      '@shikijs/primitive': 4.3.1
-      '@shikijs/types': 4.3.1
+      '@shikijs/primitive': 4.4.3
+      '@shikijs/types': 4.4.3
       '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       hast-util-to-html: 9.0.5
 
-  '@shikijs/engine-javascript@4.3.1':
+  '@shikijs/engine-javascript@4.4.3':
     dependencies:
-      '@shikijs/types': 4.3.1
+      '@shikijs/types': 4.4.3
       '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 4.3.6
 
-  '@shikijs/engine-oniguruma@4.3.1':
+  '@shikijs/engine-oniguruma@4.4.3':
     dependencies:
-      '@shikijs/types': 4.3.1
+      '@shikijs/types': 4.4.3
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@shikijs/langs@4.3.1':
+  '@shikijs/langs@4.4.3':
     dependencies:
-      '@shikijs/types': 4.3.1
+      '@shikijs/types': 4.4.3
 
-  '@shikijs/primitive@4.3.1':
+  '@shikijs/primitive@4.4.3':
     dependencies:
-      '@shikijs/types': 4.3.1
+      '@shikijs/types': 4.4.3
       '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
 
-  '@shikijs/themes@4.3.1':
+  '@shikijs/themes@4.4.3':
     dependencies:
-      '@shikijs/types': 4.3.1
+      '@shikijs/types': 4.4.3
 
-  '@shikijs/transformers@4.3.1':
+  '@shikijs/transformers@4.4.3':
     dependencies:
-      '@shikijs/core': 4.3.1
-      '@shikijs/types': 4.3.1
+      '@shikijs/core': 4.4.3
+      '@shikijs/types': 4.4.3
 
-  '@shikijs/types@4.3.1':
+  '@shikijs/types@4.4.3':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
 
   '@shikijs/vscode-textmate@10.0.2': {}
-
-  '@tybys/wasm-util@0.10.3':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
 
   '@types/debug@4.1.12':
     dependencies:
@@ -1948,6 +1905,10 @@ snapshots:
   '@types/estree@1.0.8': {}
 
   '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/hast@3.0.5':
     dependencies:
       '@types/unist': 3.0.3
 
@@ -1970,7 +1931,7 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/node@26.1.1':
+  '@types/node@26.2.0':
     dependencies:
       undici-types: 8.3.0
 
@@ -1986,49 +1947,58 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.7.0)(typescript@6.0.3))(eslint@10.7.0)(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1)(typescript@5.9.3))(eslint@10.8.1)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.65.0(eslint@10.7.0)(typescript@6.0.3)
-      '@typescript-eslint/scope-manager': 8.65.0
-      '@typescript-eslint/type-utils': 8.65.0(eslint@10.7.0)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.65.0(eslint@10.7.0)(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.65.0
-      eslint: 10.7.0
-      ignore: 7.0.5
+      '@typescript-eslint/parser': 8.67.0(eslint@10.8.1)(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.67.0
+      '@typescript-eslint/type-utils': 8.67.0(eslint@10.8.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.67.0
+      eslint: 10.8.1
+      ignore: 7.0.6
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.65.0(eslint@10.7.0)(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.67.0(eslint@10.8.1)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.65.0
-      '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.65.0
+      '@typescript-eslint/scope-manager': 8.67.0
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/typescript-estree': 8.67.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.67.0
       debug: 4.4.3
-      eslint: 10.7.0
-      typescript: 6.0.3
+      eslint: 10.8.1
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.56.0(typescript@6.0.3)':
-    dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@6.0.3)
-      '@typescript-eslint/types': 8.56.1
-      debug: 4.4.3
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/project-service@8.65.0(typescript@6.0.3)':
+  '@typescript-eslint/project-service@8.56.0(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.65.0
       debug: 4.4.3
-      typescript: 6.0.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.65.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.65.0
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.67.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.67.0
+      debug: 4.4.3
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -2042,85 +2012,120 @@ snapshots:
       '@typescript-eslint/types': 8.65.0
       '@typescript-eslint/visitor-keys': 8.65.0
 
-  '@typescript-eslint/tsconfig-utils@8.56.0(typescript@6.0.3)':
+  '@typescript-eslint/scope-manager@8.67.0':
     dependencies:
-      typescript: 6.0.3
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/visitor-keys': 8.67.0
 
-  '@typescript-eslint/tsconfig-utils@8.56.1(typescript@6.0.3)':
+  '@typescript-eslint/tsconfig-utils@8.56.0(typescript@5.9.3)':
     dependencies:
-      typescript: 6.0.3
+      typescript: 5.9.3
+
+  '@typescript-eslint/tsconfig-utils@8.65.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
 
   '@typescript-eslint/tsconfig-utils@8.65.0(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.65.0(eslint@10.7.0)(typescript@6.0.3)':
+  '@typescript-eslint/tsconfig-utils@8.67.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.65.0(eslint@10.7.0)(typescript@6.0.3)
+      typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.67.0(eslint@10.8.1)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/typescript-estree': 8.67.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1)(typescript@5.9.3)
       debug: 4.4.3
-      eslint: 10.7.0
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
+      eslint: 10.8.1
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.56.0': {}
 
-  '@typescript-eslint/types@8.56.1': {}
-
   '@typescript-eslint/types@8.65.0': {}
 
-  '@typescript-eslint/typescript-estree@8.56.0(typescript@6.0.3)':
+  '@typescript-eslint/types@8.67.0': {}
+
+  '@typescript-eslint/typescript-estree@8.56.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.56.0(typescript@6.0.3)
-      '@typescript-eslint/tsconfig-utils': 8.56.0(typescript@6.0.3)
+      '@typescript-eslint/project-service': 8.56.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.56.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.56.0
       '@typescript-eslint/visitor-keys': 8.56.0
       debug: 4.4.3
       minimatch: 9.0.5
       semver: 7.7.3
-      tinyglobby: 0.2.15
-      ts-api-utils: 2.4.0(typescript@6.0.3)
-      typescript: 6.0.3
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.65.0(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@8.65.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.65.0(typescript@6.0.3)
-      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@6.0.3)
+      '@typescript-eslint/project-service': 8.65.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.65.0
       '@typescript-eslint/visitor-keys': 8.65.0
       debug: 4.4.3
-      minimatch: 10.2.4
+      minimatch: 10.2.5
       semver: 7.7.3
-      tinyglobby: 0.2.15
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.56.0(eslint@10.7.0)(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@8.67.0(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0)
+      '@typescript-eslint/project-service': 8.67.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/visitor-keys': 8.67.0
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.7.3
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.56.0(eslint@10.8.1)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.1)
       '@typescript-eslint/scope-manager': 8.56.0
       '@typescript-eslint/types': 8.56.0
-      '@typescript-eslint/typescript-estree': 8.56.0(typescript@6.0.3)
-      eslint: 10.7.0
-      typescript: 6.0.3
+      '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.9.3)
+      eslint: 10.8.1
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.65.0(eslint@10.7.0)(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.65.0(eslint@10.8.1)(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.1)
       '@typescript-eslint/scope-manager': 8.65.0
       '@typescript-eslint/types': 8.65.0
-      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
-      eslint: 10.7.0
-      typescript: 6.0.3
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@5.9.3)
+      eslint: 10.8.1
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.67.0(eslint@10.8.1)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.1)
+      '@typescript-eslint/scope-manager': 8.67.0
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/typescript-estree': 8.67.0(typescript@5.9.3)
+      eslint: 10.8.1
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -2134,19 +2139,24 @@ snapshots:
       '@typescript-eslint/types': 8.65.0
       eslint-visitor-keys: 5.0.1
 
+  '@typescript-eslint/visitor-keys@8.67.0':
+    dependencies:
+      '@typescript-eslint/types': 8.67.0
+      eslint-visitor-keys: 5.0.1
+
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-vue@6.0.8(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1))(vue@3.5.40(typescript@6.0.3))':
+  '@vitejs/plugin-vue@6.0.8(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1))(vue@3.5.40(typescript@5.9.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)
-      vue: 3.5.40(typescript@6.0.3)
+      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.1)
+      vue: 3.5.40(typescript@5.9.3)
 
-  '@viteplus/versions@2.0.6(vitepress@2.0.0-alpha.18(@types/node@26.1.1)(esbuild@0.28.1)(postcss@8.5.20)(typescript@6.0.3))':
+  '@viteplus/versions@2.0.7(vitepress@2.0.0-alpha.19(@types/node@26.2.0)(esbuild@0.28.1)(postcss@8.5.26)(typescript@5.9.3))':
     dependencies:
       '@remotex-labs/xansi': 1.3.7
     optionalDependencies:
-      vitepress: 2.0.0-alpha.18(@types/node@26.1.1)(esbuild@0.28.1)(postcss@8.5.20)(typescript@6.0.3)
+      vitepress: 2.0.0-alpha.19(@types/node@26.2.0)(esbuild@0.28.1)(postcss@8.5.26)(typescript@5.9.3)
 
   '@vue/compiler-core@3.5.40':
     dependencies:
@@ -2178,18 +2188,18 @@ snapshots:
       '@vue/compiler-dom': 3.5.40
       '@vue/shared': 3.5.40
 
-  '@vue/devtools-api@8.1.5':
+  '@vue/devtools-api@8.2.1':
     dependencies:
-      '@vue/devtools-kit': 8.1.5
+      '@vue/devtools-kit': 8.2.1
 
-  '@vue/devtools-kit@8.1.5':
+  '@vue/devtools-kit@8.2.1':
     dependencies:
-      '@vue/devtools-shared': 8.1.5
+      '@vue/devtools-shared': 8.2.1
       birpc: 2.6.1
       hookable: 5.5.3
       perfect-debounce: 2.0.0
 
-  '@vue/devtools-shared@8.1.5': {}
+  '@vue/devtools-shared@8.2.1': {}
 
   '@vue/reactivity@3.5.40':
     dependencies:
@@ -2215,26 +2225,26 @@ snapshots:
 
   '@vue/shared@3.5.40': {}
 
-  '@vueuse/core@14.3.0(vue@3.5.40(typescript@6.0.3))':
+  '@vueuse/core@14.4.0(vue@3.5.40(typescript@5.9.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.21
-      '@vueuse/metadata': 14.3.0
-      '@vueuse/shared': 14.3.0(vue@3.5.40(typescript@6.0.3))
-      vue: 3.5.40(typescript@6.0.3)
+      '@vueuse/metadata': 14.4.0
+      '@vueuse/shared': 14.4.0(vue@3.5.40(typescript@5.9.3))
+      vue: 3.5.40(typescript@5.9.3)
 
-  '@vueuse/integrations@14.3.0(focus-trap@8.2.2)(vue@3.5.40(typescript@6.0.3))':
+  '@vueuse/integrations@14.4.0(focus-trap@8.2.2)(vue@3.5.40(typescript@5.9.3))':
     dependencies:
-      '@vueuse/core': 14.3.0(vue@3.5.40(typescript@6.0.3))
-      '@vueuse/shared': 14.3.0(vue@3.5.40(typescript@6.0.3))
-      vue: 3.5.40(typescript@6.0.3)
+      '@vueuse/core': 14.4.0(vue@3.5.40(typescript@5.9.3))
+      '@vueuse/shared': 14.4.0(vue@3.5.40(typescript@5.9.3))
+      vue: 3.5.40(typescript@5.9.3)
     optionalDependencies:
       focus-trap: 8.2.2
 
-  '@vueuse/metadata@14.3.0': {}
+  '@vueuse/metadata@14.4.0': {}
 
-  '@vueuse/shared@14.3.0(vue@3.5.40(typescript@6.0.3))':
+  '@vueuse/shared@14.4.0(vue@3.5.40(typescript@5.9.3))':
     dependencies:
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.5.40(typescript@5.9.3)
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -2271,10 +2281,6 @@ snapshots:
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
-
-  brace-expansion@5.0.2:
-    dependencies:
-      balanced-match: 4.0.3
 
   brace-expansion@5.0.7:
     dependencies:
@@ -2369,20 +2375,20 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-perfectionist@5.10.0(eslint@10.7.0)(typescript@6.0.3):
+  eslint-plugin-perfectionist@5.10.1(eslint@10.8.1)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/utils': 8.65.0(eslint@10.7.0)(typescript@6.0.3)
-      eslint: 10.7.0
+      '@typescript-eslint/utils': 8.65.0(eslint@10.8.1)(typescript@5.9.3)
+      eslint: 10.8.1
       natural-orderby: 5.0.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-tsdoc@0.5.2(eslint@10.7.0)(typescript@6.0.3):
+  eslint-plugin-tsdoc@0.5.2(eslint@10.8.1)(typescript@5.9.3):
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@typescript-eslint/utils': 8.56.0(eslint@10.7.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.56.0(eslint@10.8.1)(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -2399,12 +2405,12 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.7.0:
+  eslint@10.8.1:
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.1)
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.23.5
-      '@eslint/config-helpers': 0.6.0
+      '@eslint/config-helpers': 0.7.0
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.2
       '@humanfs/node': 0.16.7
@@ -2428,7 +2434,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
-      minimatch: 10.2.4
+      minimatch: 10.2.5
       natural-compare: 1.4.0
       optionator: 0.9.4
     transitivePeerDependencies:
@@ -2461,10 +2467,6 @@ snapshots:
   fast-levenshtein@2.0.6: {}
 
   fast-uri@3.1.0: {}
-
-  fdir@6.5.0(picomatch@4.0.3):
-    optionalDependencies:
-      picomatch: 4.0.3
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -2532,8 +2534,6 @@ snapshots:
   html-void-elements@3.0.0: {}
 
   ignore@5.3.2: {}
-
-  ignore@7.0.5: {}
 
   ignore@7.0.6: {}
 
@@ -2884,10 +2884,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  minimatch@10.2.4:
-    dependencies:
-      brace-expansion: 5.0.2
-
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.7
@@ -2903,6 +2899,8 @@ snapshots:
   ms@2.1.3: {}
 
   nanoid@3.3.16: {}
+
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -2953,13 +2951,17 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@4.0.3: {}
-
   picomatch@4.0.5: {}
 
   postcss@8.5.20:
     dependencies:
       nanoid: 3.3.16
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -2989,26 +2991,25 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  rolldown@1.1.5:
+  rolldown@1.2.3:
     dependencies:
-      '@oxc-project/types': 0.139.0
+      '@oxc-project/types': 0.143.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.1.5
-      '@rolldown/binding-darwin-arm64': 1.1.5
-      '@rolldown/binding-darwin-x64': 1.1.5
-      '@rolldown/binding-freebsd-x64': 1.1.5
-      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
-      '@rolldown/binding-linux-arm64-gnu': 1.1.5
-      '@rolldown/binding-linux-arm64-musl': 1.1.5
-      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
-      '@rolldown/binding-linux-s390x-gnu': 1.1.5
-      '@rolldown/binding-linux-x64-gnu': 1.1.5
-      '@rolldown/binding-linux-x64-musl': 1.1.5
-      '@rolldown/binding-openharmony-arm64': 1.1.5
-      '@rolldown/binding-wasm32-wasi': 1.1.5
-      '@rolldown/binding-win32-arm64-msvc': 1.1.5
-      '@rolldown/binding-win32-x64-msvc': 1.1.5
+      '@rolldown/binding-android-arm64': 1.2.3
+      '@rolldown/binding-darwin-arm64': 1.2.3
+      '@rolldown/binding-darwin-x64': 1.2.3
+      '@rolldown/binding-freebsd-x64': 1.2.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.3
+      '@rolldown/binding-linux-arm64-gnu': 1.2.3
+      '@rolldown/binding-linux-arm64-musl': 1.2.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.3
+      '@rolldown/binding-linux-s390x-gnu': 1.2.3
+      '@rolldown/binding-linux-x64-gnu': 1.2.3
+      '@rolldown/binding-linux-x64-musl': 1.2.3
+      '@rolldown/binding-openharmony-arm64': 1.2.3
+      '@rolldown/binding-win32-arm64-msvc': 1.2.3
+      '@rolldown/binding-win32-x64-msvc': 1.2.3
 
   run-con@1.3.3:
     dependencies:
@@ -3025,16 +3026,16 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shiki@4.3.1:
+  shiki@4.4.3:
     dependencies:
-      '@shikijs/core': 4.3.1
-      '@shikijs/engine-javascript': 4.3.1
-      '@shikijs/engine-oniguruma': 4.3.1
-      '@shikijs/langs': 4.3.1
-      '@shikijs/themes': 4.3.1
-      '@shikijs/types': 4.3.1
+      '@shikijs/core': 4.4.3
+      '@shikijs/engine-javascript': 4.4.3
+      '@shikijs/engine-oniguruma': 4.4.3
+      '@shikijs/langs': 4.4.3
+      '@shikijs/themes': 4.4.3
+      '@shikijs/types': 4.4.3
       '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
 
   smol-toml@1.7.0: {}
 
@@ -3068,11 +3069,6 @@ snapshots:
 
   tabbable@6.5.0: {}
 
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
@@ -3080,31 +3076,30 @@ snapshots:
 
   trim-lines@3.0.1: {}
 
-  ts-api-utils@2.4.0(typescript@6.0.3):
+  ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
-      typescript: 6.0.3
+      typescript: 5.9.3
 
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
 
-  tslib@2.8.1:
-    optional: true
-
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
 
-  typescript-eslint@8.65.0(eslint@10.7.0)(typescript@6.0.3):
+  typescript-eslint@8.67.0(eslint@10.8.1)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.7.0)(typescript@6.0.3))(eslint@10.7.0)(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.65.0(eslint@10.7.0)(typescript@6.0.3)
-      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.65.0(eslint@10.7.0)(typescript@6.0.3)
-      eslint: 10.7.0
-      typescript: 6.0.3
+      '@typescript-eslint/eslint-plugin': 8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1)(typescript@5.9.3))(eslint@10.8.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.67.0(eslint@10.8.1)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.67.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1)(typescript@5.9.3)
+      eslint: 10.8.1
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
+
+  typescript@5.9.3: {}
 
   typescript@6.0.2: {}
 
@@ -3151,41 +3146,41 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1):
+  vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
-      postcss: 8.5.20
-      rolldown: 1.1.5
+      postcss: 8.5.26
+      rolldown: 1.2.3
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.2.0
       esbuild: 0.28.1
       fsevents: 2.3.3
 
-  vitepress@2.0.0-alpha.18(@types/node@26.1.1)(esbuild@0.28.1)(postcss@8.5.20)(typescript@6.0.3):
+  vitepress@2.0.0-alpha.19(@types/node@26.2.0)(esbuild@0.28.1)(postcss@8.5.26)(typescript@5.9.3):
     dependencies:
-      '@docsearch/css': 4.6.3
-      '@docsearch/js': 4.6.3
-      '@docsearch/sidepanel-js': 4.6.3
-      '@iconify-json/simple-icons': 1.2.91
-      '@shikijs/core': 4.3.1
-      '@shikijs/transformers': 4.3.1
-      '@shikijs/types': 4.3.1
+      '@docsearch/css': 4.7.0
+      '@docsearch/js': 4.7.0
+      '@docsearch/sidepanel-js': 4.7.0
+      '@iconify-json/simple-icons': 1.2.93
+      '@shikijs/core': 4.4.3
+      '@shikijs/transformers': 4.4.3
+      '@shikijs/types': 4.4.3
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 6.0.8(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1))(vue@3.5.40(typescript@6.0.3))
-      '@vue/devtools-api': 8.1.5
+      '@vitejs/plugin-vue': 6.0.8(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1))(vue@3.5.40(typescript@5.9.3))
+      '@vue/devtools-api': 8.2.1
       '@vue/shared': 3.5.40
-      '@vueuse/core': 14.3.0(vue@3.5.40(typescript@6.0.3))
-      '@vueuse/integrations': 14.3.0(focus-trap@8.2.2)(vue@3.5.40(typescript@6.0.3))
+      '@vueuse/core': 14.4.0(vue@3.5.40(typescript@5.9.3))
+      '@vueuse/integrations': 14.4.0(focus-trap@8.2.2)(vue@3.5.40(typescript@5.9.3))
       focus-trap: 8.2.2
       mark.js: 8.11.1
       minisearch: 7.2.0
-      shiki: 4.3.1
-      vite: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)
-      vue: 3.5.40(typescript@6.0.3)
+      shiki: 4.4.3
+      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.1)
+      vue: 3.5.40(typescript@5.9.3)
     optionalDependencies:
-      postcss: 8.5.20
+      postcss: 8.5.26
     transitivePeerDependencies:
       - '@types/node'
       - '@vitejs/devtools'
@@ -3212,7 +3207,7 @@ snapshots:
       - universal-cookie
       - yaml
 
-  vue@3.5.40(typescript@6.0.3):
+  vue@3.5.40(typescript@5.9.3):
     dependencies:
       '@vue/compiler-dom': 3.5.40
       '@vue/compiler-sfc': 3.5.40
@@ -3220,7 +3215,7 @@ snapshots:
       '@vue/server-renderer': 3.5.40
       '@vue/shared': 3.5.40
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 5.9.3
 
   which@2.0.2:
     dependencies:

--- a/src/components/rewrites-component.spec.ts
+++ b/src/components/rewrites-component.spec.ts
@@ -62,6 +62,8 @@ describe('parseRoutesComponent', () => {
         );
 
         const mockState: any = {
+            sources: 'src',
+            archive: 'archive',
             localesMap: { en: 'en', fr: 'fr' },
             versionsConfig: { hooks: { rewritesHook: mockRewritesHook } },
             vitepressConfig: {}
@@ -79,6 +81,8 @@ describe('parseRoutesComponent', () => {
         );
 
         const mockState: any = {
+            sources: 'src',
+            archive: 'archive',
             localesMap: { en: 'en', fr: 'fr' },
             versionsConfig: { hooks: { rewritesHook: mockRewritesHook } },
             vitepressConfig: {}
@@ -100,6 +104,8 @@ describe('parseRoutesComponent', () => {
         );
 
         const mockState: any = {
+            sources: 'src',
+            archive: 'archive',
             localesMap: { en: 'root' },
             versionsConfig: { hooks: { rewritesHook: mockRewritesHook } },
             vitepressConfig: {}
@@ -117,6 +123,8 @@ describe('parseRoutesComponent', () => {
 
     test('should handle src/ files without locale prefix', () => {
         const mockState: any = {
+            sources: 'src',
+            archive: 'archive',
             localesMap: { en: 'en' },
             versionsConfig: { hooks: { rewritesHook: xJet.fn() } },
             vitepressConfig: {}
@@ -137,6 +145,8 @@ describe('parseRoutesComponent', () => {
         );
 
         const mockState: any = {
+            sources: 'src',
+            archive: 'archive',
             localesMap: { en: 'en' },
             versionsList: [ 'v1.0.0', 'v2.0.0' ],
             versionsConfig: { hooks: { rewritesHook: mockRewritesHook } },
@@ -159,6 +169,8 @@ describe('parseRoutesComponent', () => {
         );
 
         const mockState: any = {
+            sources: 'src',
+            archive: 'archive',
             localesMap: { en: 'root' },
             versionsList: [ 'v1.0.0', 'v2.0.0' ],
             versionsConfig: { hooks: { rewritesHook: mockRewritesHook } },
@@ -177,6 +189,8 @@ describe('parseRoutesComponent', () => {
 
     test('should handle files that do not match src/ or archive/ patterns', () => {
         const mockState: any = {
+            sources: 'src',
+            archive: 'archive',
             localesMap: { en: 'en' },
             versionsConfig: { hooks: { rewritesHook: xJet.fn() } },
             vitepressConfig: {}
@@ -197,6 +211,8 @@ describe('parseRoutesComponent', () => {
         );
 
         const mockState: any = {
+            sources: 'src',
+            archive: 'archive',
             localesMap: { en: 'en', fr: 'fr' },
             versionsList: [ 'v1.0.0', 'v2.0.0' ],
             versionsConfig: { hooks: { rewritesHook: mockRewritesHook } },
@@ -224,6 +240,8 @@ describe('parseRoutesComponent', () => {
         );
 
         const mockState: any = {
+            sources: 'src',
+            archive: 'archive',
             localesMap: { en: 'en' },
             versionsList: [ 'v1.0.0', 'v2.0.0' ],
             versionsConfig: { hooks: { rewritesHook: mockRewritesHook } },
@@ -238,5 +256,30 @@ describe('parseRoutesComponent', () => {
 
         expect(mockRewritesHook).toHaveBeenCalledWith('docs/api/reference.md', 'v1.0.0', 'en');
         expect(result).toBe('en/v1.0.0/docs/api/reference.md');
+    });
+
+    test('should honor custom sources and archive directory names', () => {
+        const mockRewritesHook = xJet.fn(
+            (file: string, version: string, locale: string) => join(locale, version, file)
+        );
+
+        const mockState: any = {
+            sources: 'latest',
+            archive: 'versions',
+            localesMap: { en: 'root' },
+            versionsList: [ 'v1.0.0' ],
+            versionsConfig: { hooks: { rewritesHook: mockRewritesHook } },
+            vitepressConfig: {}
+        };
+
+        mockInject.mockReturnValue(mockState);
+        parseRoutesComponent();
+
+        const rewriteFn = mockState.vitepressConfig.rewrites;
+
+        expect(rewriteFn('latest/en/index.md')).toBe('index.md');
+        expect(rewriteFn('latest/guide/intro.md')).toBe('guide/intro.md');
+        expect(rewriteFn('versions/v1.0.0/en/index.md')).toBe('v1.0.0/index.md');
+        expect(rewriteFn('src/en/index.md')).toBe('src/en/index.md');
     });
 });

--- a/src/components/rewrites.component.ts
+++ b/src/components/rewrites.component.ts
@@ -144,16 +144,18 @@ export function parseRoutesComponent(): void {
     const localesPrefix = Object.keys(state.localesMap);
     const localesList = Object.keys(state.localesMap);
     const versionsList = state.versionsList;
+    const sourcesPrefix = `${ state.sources }/`;
+    const archivePrefix = `${ state.archive }/`;
 
     state.vitepressConfig.rewrites = function (id: string): string {
-        // Handle src/ files
-        if (id.startsWith('src/')) {
-            const path = id.replace('src/', '');
+        // Handle sources files
+        if (id.startsWith(sourcesPrefix)) {
+            const path = id.slice(sourcesPrefix.length);
             const localeKey = localesPrefix.find(prefix => path.startsWith(prefix + '/'));
 
             if (localeKey) {
                 const locale = state.localesMap[localeKey] === 'root' ? '' : localeKey;
-                const filePath = path.replace(localeKey + '/', '');
+                const filePath = path.slice(localeKey.length + 1);
 
                 return state.versionsConfig.hooks.rewritesHook(filePath, '', locale);
             }
@@ -161,9 +163,9 @@ export function parseRoutesComponent(): void {
             return path;
         }
 
-        // Handle archive/ files
-        if (id.startsWith('archive/')) {
-            const path = id.replace('archive/', '');
+        // Handle archive files
+        if (id.startsWith(archivePrefix)) {
+            const path = id.slice(archivePrefix.length);
             const segments = path.split('/');
             const { lang, version } = extractLocale(segments, localesList, versionsList);
             const source = segments.join('/');


### PR DESCRIPTION
Fixes #31.

Changing `versionsConfig.sources` to anything other than `src` leaked the directory
name into every URL — with `sources: 'latest'` the home page was served at
`/versions/latest/` instead of `/versions/`.

`StateModel` already honors `sources` and `archive` when it resolves paths, 
but the rewrites function built in `parseRoutesComponent` matched the directory names as string literals:

```ts
if (id.startsWith('src/')) { ... }
if (id.startsWith('archive/')) { ... }
return id;                            // fallthrough: id returned unrewritten
```

Any other directory name matched neither branch, so the id was returned as-is and
the folder name became part of the route. The same applied to archive, which
would have put the archive folder name into every versioned URL.

This derives both prefixes from the state model instead:

const sourcesPrefix = `${ state.sources }/`;
const archivePrefix = `${ state.archive }/`;

The two .replace(prefix, '') calls were also swapped for .slice(). replace
matches the first occurrence anywhere in the string, so a path such as
guide/src/intro.md under a locale would have been mangled.
